### PR TITLE
Redesign hero section with full-width call-to-action

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,46 +25,50 @@
     </div>
   </header>
 
-  <main class="container">
-  
-<section class="hero">
-  <div>
-    <h1 class="headline">Turn Your Parking Lot Into a Reliable Revenue Stream</h1>
-    <p class="sub">Most parking lot owners are sitting on untapped income. We make it easy — automated enforcement, proven revenue strategies, and full support.</p>
-    <p style="margin-top:16px"><a class="cta" href="contact.html">Get Your Free Parking Revenue Assessment</a></p>
+  <main>
 
-    <div class="grid3" style="margin-top:24px">
-      <div class="card">
-        <strong>Increase Revenue</strong>
-        <p class="small">Monetize every space with automated monitoring and enforcement.</p>
-      </div>
-      <div class="card">
-        <strong>Save Time</strong>
-        <p class="small">Let the system handle ticketing and tracking while you focus on other things.</p>
-      </div>
-      <div class="card">
-        <strong>Proven Results</strong>
-        <p class="small">Owners report consistent revenue growth within months of setup.</p>
-      </div>
-    </div>
-
-    <section style="margin-top:28px" class="card">
-      <h2>How It Works</h2>
-      <div class="grid3">
-        <div><strong>1. Free Assessment</strong><div class="small">We estimate your lot's earning potential.</div></div>
-        <div><strong>2. Fast Setup</strong><div class="small">Simple install and training — no heavy IT required.</div></div>
-        <div><strong>3. Start Earning</strong><div class="small">Automated enforcement and reporting turn spaces into income.</div></div>
+    <section class="hero">
+      <div class="container">
+        <h1 class="headline">Stop Losing Parking Revenue. Upgrade to Automated AI Enforcement Today.</h1>
+        <p class="sub">Most parking lot owners are sitting on untapped income. We make it easy — automated enforcement, proven revenue strategies, and full support.</p>
+        <div class="hero-actions">
+          <a class="cta" href="contact.html">Get Your Free Parking Revenue Assessment</a>
+          <a class="cta secondary" href="calculator.html">Try the Parking Revenue Calculator</a>
+        </div>
       </div>
     </section>
 
-    <p style="margin-top:24px"><a class="cta" href="calculator.html">Try the Parking Revenue Calculator</a></p>
-  </div>
-</section>
+    <section class="container">
+      <div class="grid3" style="margin-top:24px">
+        <div class="card">
+          <strong>Increase Revenue</strong>
+          <p class="small">Monetize every space with automated monitoring and enforcement.</p>
+        </div>
+        <div class="card">
+          <strong>Save Time</strong>
+          <p class="small">Let the system handle ticketing and tracking while you focus on other things.</p>
+        </div>
+        <div class="card">
+          <strong>Proven Results</strong>
+          <p class="small">Owners report consistent revenue growth within months of setup.</p>
+        </div>
+      </div>
+    </section>
 
-  <footer>
-    <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+    <section class="container" style="margin-top:28px">
+      <div class="card">
+        <h2>How It Works</h2>
+        <div class="grid3">
+          <div><strong>1. Free Assessment</strong><div class="small">We estimate your lot's earning potential.</div></div>
+          <div><strong>2. Fast Setup</strong><div class="small">Simple install and training — no heavy IT required.</div></div>
+          <div><strong>3. Start Earning</strong><div class="small">Automated enforcement and reporting turn spaces into income.</div></div>
+        </div>
+      </div>
+    </section>
 
-</footer>
-</main>
+    <footer>
+      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+    </footer>
+  </main>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -29,7 +29,33 @@ h2{font-size:1.375rem;line-height:1.25;margin:0 0 12px 0}
 h3{font-size:1.125rem;margin:0 0 6px 0}
 p{margin:0 0 10px 0}
 .section{margin:44px 0}
-.hero{display:grid;grid-template-columns:1fr;gap:28px;padding:36px 0;align-items:center}
+.hero{
+  background:var(--brand);
+  color:#fff;
+  text-align:center;
+  padding:80px 0;
+}
+.hero .headline{
+  font-size:2.5rem;
+  font-weight:800;
+}
+.hero .sub{
+  color:#f1f5f9;
+  margin:8px auto 0;
+  max-width:60ch;
+}
+.hero-actions{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  margin-top:20px;
+  align-items:center;
+}
+@media(min-width:600px){
+  .hero-actions{flex-direction:row;justify-content:center}
+}
+.hero .cta{background:#fff;color:var(--brand)}
+.hero .cta.secondary{background:transparent;color:#fff;border:1px solid #fff}
 .sub{color:var(--muted);margin-top:8px;max-width:60ch}
 .cta{display:inline-block;background:var(--brand);color:#fff;padding:12px 18px;border-radius:10px;text-decoration:none;font-weight:700}
 .cta.secondary{background:#1118270d;color:var(--brand);border:1px solid var(--border)}
@@ -49,12 +75,11 @@ footer{margin-top:56px;padding:28px 0;color:var(--muted);text-align:center;borde
 .pill{display:inline-block;background:#eef2ff;border-radius:999px;padding:5px 12px;font-size:.8125rem;margin-bottom:8px;border:1px solid #e0e7ff}
 .kicker{letter-spacing:.18em;text-transform:uppercase;font-weight:700;font-size:.8125rem;color:var(--muted);margin-bottom:8px}
 .breadcrumb{font-size:.9375rem;color:var(--muted);margin:10px 0 18px 0}
-.hero-actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
+
 input,select,textarea{width:100%;padding:12px;border:1px solid var(--border);border-radius:10px;font-size:1rem}
 .row{display:flex;gap:10px;margin-bottom:10px}
 @media(min-width:920px){
-  .hero{grid-template-columns:1.2fr .8fr}
-  h1{font-size:2.375rem}
+  .hero .headline{font-size:2.875rem}
 }
 
 .section-block{scroll-margin-top:100px}


### PR DESCRIPTION
## Summary
- Give the hero section a full-width brand background with centered content
- Add bold headline, subhead, and two CTA buttons that stack on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7afe6c484832b888390f8e293c28e