### PR TITLE
Split Resources articles into individual pages

### DIFF
--- a/case-study.html
+++ b/case-study.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Case Study: Revenue Growth in a 45-Space Lot | ParkingProfit Solutions</title>
+  <meta name="description" content="See how a 45-space parking lot boosted revenue by 55% and cut costs after adopting AI-powered enforcement.">
+  <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container nav">
+      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
+      <nav>
+        <a href="index.html" class="">Home</a>
+        <a href="services.html" class="">Services</a>
+        <a href="resources.html" class="active">Resources</a>
+        <a href="faq.html" class="">FAQ</a>
+        <a href="contact.html" class="">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <div class="section">
+      <div class="kicker">Resources</div>
+      <h1>Case Study: Revenue Growth in a 45-Space Lot</h1>
+      <p>A downtown property owner switched from a cash box + attendant to an AI-powered enforcement system. Within 90 days:</p>
+      <ul>
+        <li>Revenue grew by 55%</li>
+        <li>Operating costs dropped to near zero</li>
+        <li>Compliance rates climbed above 90%</li>
+      </ul>
+      <p>By year’s end, the system had paid for itself twice over — while freeing the owner from manual oversight.</p>
+      <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
+    </div>
+    <footer>
+      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+    </footer>
+  </main>
+</body>
+</html>

--- a/gate-arms.html
+++ b/gate-arms.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Why Gate Arms Cost More Than They Earn | ParkingProfit Solutions</title>
+  <meta name="description" content="Gate arms add installation and maintenance costs while frustrating drivers. See why AI enforcement is a better solution.">
+  <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container nav">
+      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
+      <nav>
+        <a href="index.html" class="">Home</a>
+        <a href="services.html" class="">Services</a>
+        <a href="resources.html" class="active">Resources</a>
+        <a href="faq.html" class="">FAQ</a>
+        <a href="contact.html" class="">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <div class="section">
+      <div class="kicker">Resources</div>
+      <h1>Why Gate Arms Cost More Than They Earn</h1>
+      <p>Gate arms require costly installation, ongoing maintenance, and frequent repairs. They also slow traffic flow, leading to customer frustration. In many cases, the cost of ownership outweighs the revenue they protect.</p>
+      <p>AI enforcement eliminates these issues by allowing free-flow entry and exit while still capturing every violation and payment digitally.</p>
+    </div>
+    <footer>
+      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+    </footer>
+  </main>
+</body>
+</html>

--- a/make-money.html
+++ b/make-money.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>How to Make Money From Your Parking Lot | ParkingProfit Solutions</title>
+  <meta name="description" content="Learn monetization models, pricing strategies, and enforcement tips to make money from your parking lot.">
+  <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container nav">
+      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
+      <nav>
+        <a href="index.html" class="">Home</a>
+        <a href="services.html" class="">Services</a>
+        <a href="resources.html" class="active">Resources</a>
+        <a href="faq.html" class="">FAQ</a>
+        <a href="contact.html" class="">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <div class="section">
+      <div class="kicker">Resources</div>
+      <h1>How to Make Money From Your Parking Lot</h1>
+      <p>Parking lots are often overlooked as investment assets, but the right approach can turn asphalt into a steady profit center. This flagship guide covers everything from monetization models and pricing strategies to enforcement and long-term ROI.</p>
+      <h2>Monetization Models</h2>
+      <p>Choose between hourly, daily, event-based, or monthly passes depending on your market. Hybrid approaches work well for mixed-demand locations.</p>
+      <h2>Pricing That Drives Occupancy</h2>
+      <p>Survey competitors, track fill rates, and experiment with dynamic pricing. AI systems can automatically adjust rates to capture peak demand while filling slow periods.</p>
+      <h2>Automated Enforcement</h2>
+      <p>Without enforcement, 20–30% of potential revenue is lost. AI-powered enforcement ensures compliance with license plate recognition, photo evidence, and online payments — no attendants or gate arms required.</p>
+      <h2>ROI Example</h2>
+      <p>A 50-space lot, priced at $5/day with 60% occupancy, makes about $4,500/month. With AI enforcement improving compliance and pricing optimization, that same lot can generate $6,000+ monthly. Over a year, that’s an $18,000+ gain.</p>
+      <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
+    </div>
+    <footer>
+      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+    </footer>
+  </main>
+</body>
+</html>

--- a/mistakes.html
+++ b/mistakes.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>5 Common Mistakes Parking Lot Owners Make | ParkingProfit Solutions</title>
+  <meta name="description" content="Avoid revenue loss by learning the top mistakes parking lot owners make, from poor enforcement to ignoring pricing data.">
+  <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container nav">
+      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
+      <nav>
+        <a href="index.html" class="">Home</a>
+        <a href="services.html" class="">Services</a>
+        <a href="resources.html" class="active">Resources</a>
+        <a href="faq.html" class="">FAQ</a>
+        <a href="contact.html" class="">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <div class="section">
+      <div class="kicker">Resources</div>
+      <h1>5 Common Mistakes Parking Lot Owners Make</h1>
+      <ul>
+        <li>Relying on attendants who increase costs and create inconsistencies</li>
+        <li>Using outdated gate arms that break down and frustrate drivers</li>
+        <li>Failing to enforce properly, leading to unpaid usage</li>
+        <li>Ignoring occupancy data and pricing opportunities</li>
+        <li>Delaying adoption of automation until revenue has already declined</li>
+      </ul>
+    </div>
+    <footer>
+      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+    </footer>
+  </main>
+</body>
+</html>

--- a/resources.html
+++ b/resources.html
@@ -32,91 +32,43 @@
   </header>
 
   <main class="container">
-<div class="two-col">
-  
-<aside class="sidenav card" style="margin-top:8px">
-  <div class="small" style="margin-bottom:8px;font-weight:700">On this page</div>
-  <ul class="menu">
-    <li><a href="#flagship">Flagship Guide</a></li>
-    <li><a href="#mistakes">Common Mistakes</a></li>
-    <li><a href="#gate-arms">Gate Arms vs AI</a></li>
-    <li><a href="#roi-ai">ROI of AI Enforcement</a></li>
-    <li><a href="#case-study">Case Study</a></li>
-  </ul>
-</aside>
+    <div class="section">
+      <div class="kicker">Resources</div>
+      <h1>Parking Lot Owner Resources &amp; Guides</h1>
+      <p class="sub">Explore expert guides, tips, and case studies to help you maximize revenue, reduce costs, and transition from outdated parking systems to modern AI automation.</p>
+    </div>
 
-  <div>
-    
+    <div class="grid3" style="margin-top:24px">
+      <div class="card">
+        <h3>How to Make Money From Your Parking Lot</h3>
+        <p class="small">Turn your asphalt into a profit center with smart pricing, monetization models, and AI enforcement.</p>
+        <a class="cta secondary" href="make-money.html">Read More</a>
+      </div>
+      <div class="card">
+        <h3>5 Common Mistakes Parking Lot Owners Make</h3>
+        <p class="small">Avoid revenue-draining missteps like outdated gate arms and inconsistent enforcement.</p>
+        <a class="cta secondary" href="mistakes.html">Read More</a>
+      </div>
+      <div class="card">
+        <h3>Why Gate Arms Cost More Than They Earn</h3>
+        <p class="small">Physical barriers are expensive and slow traffic. See why AI enforcement is a better investment.</p>
+        <a class="cta secondary" href="gate-arms.html">Read More</a>
+      </div>
+      <div class="card">
+        <h3>The ROI of AI Parking Enforcement</h3>
+        <p class="small">AI automation delivers quick payback by cutting costs and boosting compliance.</p>
+        <a class="cta secondary" href="roi-ai.html">Read More</a>
+      </div>
+      <div class="card">
+        <h3>Case Study: Revenue Growth in a 45-Space Lot</h3>
+        <p class="small">See how one owner increased revenue by 55% after adopting AI enforcement.</p>
+        <a class="cta secondary" href="case-study.html">Read More</a>
+      </div>
+    </div>
 
-<div class="two-col">
-  
-
-  <div>
-
-
-<div class="section">
-  <div class="kicker">Resources</div>
-  <h1>Parking Lot Owner Resources & Guides</h1>
-  <p class="sub">Explore expert guides, tips, and case studies to help you maximize revenue, reduce costs, and transition from outdated parking systems to modern AI automation.</p>
-</div>
-
-<div class="section-block">
-  <h2 id="flagship">Flagship Guide: How to Make Money From Your Parking Lot</h2>
-  <p>Parking lots are often overlooked as investment assets, but the right approach can turn asphalt into a steady profit center. This flagship guide covers everything from monetization models and pricing strategies to enforcement and long-term ROI.</p>
-  <h3>Monetization Models</h3>
-  <p>Choose between hourly, daily, event-based, or monthly passes depending on your market. Hybrid approaches work well for mixed-demand locations.</p>
-  <h3>Pricing That Drives Occupancy</h3>
-  <p>Survey competitors, track fill rates, and experiment with dynamic pricing. AI systems can automatically adjust rates to capture peak demand while filling slow periods.</p>
-  <h3>Automated Enforcement</h3>
-  <p>Without enforcement, 20–30% of potential revenue is lost. AI-powered enforcement ensures compliance with license plate recognition, photo evidence, and online payments — no attendants or gate arms required.</p>
-  <h3>ROI Example</h3>
-  <p>A 50-space lot, priced at $5/day with 60% occupancy, makes about $4,500/month. With AI enforcement improving compliance and pricing optimization, that same lot can generate $6,000+ monthly. Over a year, that’s an $18,000+ gain.</p>
-  <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
-</div>
-
-<div class="section-block">
-  <h2 id="mistakes">5 Common Mistakes Parking Lot Owners Make</h2>
-  <ul>
-    <li>Relying on attendants who increase costs and create inconsistencies</li>
-    <li>Using outdated gate arms that break down and frustrate drivers</li>
-    <li>Failing to enforce properly, leading to unpaid usage</li>
-    <li>Ignoring occupancy data and pricing opportunities</li>
-    <li>Delaying adoption of automation until revenue has already declined</li>
-  </ul>
-</div>
-
-<div class="section-block">
-  <h2 id="gatearms">Why Gate Arms Cost More Than They Earn</h2>
-  <p>Gate arms require costly installation, ongoing maintenance, and frequent repairs. They also slow traffic flow, leading to customer frustration. In many cases, the cost of ownership outweighs the revenue they protect.</p>
-  <p>AI enforcement eliminates these issues by allowing free-flow entry and exit while still capturing every violation and payment digitally.</p>
-</div>
-
-<div class="section-block">
-  <h2 id="roi">The ROI of AI Parking Enforcement</h2>
-  <p>AI solutions reduce staffing, minimize equipment overhead, and ensure higher compliance. For most lots, ROI is reached within the first 6–9 months of deployment, making automation one of the fastest ways to improve profit margins.</p>
-</div>
-
-<div class="section-block">
-  <h2 id="casestudy">Case Study: Revenue Growth in a 45-Space Lot</h2>
-  <p>A downtown property owner switched from a cash box + attendant to an AI-powered enforcement system. Within 90 days:</p>
-  <ul>
-    <li>Revenue grew by 55%</li>
-    <li>Operating costs dropped to near zero</li>
-    <li>Compliance rates climbed above 90%</li>
-  </ul>
-  <p>By year’s end, the system had paid for itself twice over — while freeing the owner from manual oversight.</p>
-  <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
-</div>
-
-
-  </div>
-</div>
-
-  </div>
-</div>
-<footer>
-    <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-  </footer>
+    <footer>
+      <div class="small">&copy; <span id="year"></span> ParkingProfit Solutions &mdash; Built for parking lot owners who want results.</div>
+    </footer>
   </main>
 </body>
 </html>

--- a/roi-ai.html
+++ b/roi-ai.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>The ROI of AI Parking Enforcement | ParkingProfit Solutions</title>
+  <meta name="description" content="AI parking enforcement reduces staffing and equipment costs while improving compliance, delivering ROI within months.">
+  <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
+</head>
+<body>
+  <header>
+    <div class="container nav">
+      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
+      <nav>
+        <a href="index.html" class="">Home</a>
+        <a href="services.html" class="">Services</a>
+        <a href="resources.html" class="active">Resources</a>
+        <a href="faq.html" class="">FAQ</a>
+        <a href="contact.html" class="">Contact</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+    <div class="section">
+      <div class="kicker">Resources</div>
+      <h1>The ROI of AI Parking Enforcement</h1>
+      <p>AI solutions reduce staffing, minimize equipment overhead, and ensure higher compliance. For most lots, ROI is reached within the first 6–9 months of deployment, making automation one of the fastest ways to improve profit margins.</p>
+    </div>
+    <footer>
+      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+    </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extract each Resources article into its own page with consistent site header, footer, and styling
- show article previews on Resources page linking to the new pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b4bcdc48832b9745fb72ff69f79d