### PR TITLE
Add sidebar navigation for articles and tidy resource cards

### DIFF
--- a/case-study.html
+++ b/case-study.html
@@ -8,6 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
+  <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
 </head>
 <body>
@@ -25,21 +26,35 @@
   </header>
 
   <main class="container">
-    <div class="section">
-      <div class="kicker">Resources</div>
-      <h1>Case Study: Revenue Growth in a 45-Space Lot</h1>
-      <p>A downtown property owner switched from a cash box + attendant to an AI-powered enforcement system. Within 90 days:</p>
-      <ul>
-        <li>Revenue grew by 55%</li>
-        <li>Operating costs dropped to near zero</li>
-        <li>Compliance rates climbed above 90%</li>
-      </ul>
-      <p>By year’s end, the system had paid for itself twice over — while freeing the owner from manual oversight.</p>
-      <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
+    <div class="two-col">
+      <aside class="sidenav card">
+        <div class="small" style="margin-bottom:8px;font-weight:700">Related Articles</div>
+        <ul class="menu">
+          <li><a href="make-money.html">How to Make Money From Your Parking Lot</a></li>
+          <li><a href="mistakes.html">5 Common Mistakes Parking Lot Owners Make</a></li>
+          <li><a href="gate-arms.html">Why Gate Arms Cost More Than They Earn</a></li>
+          <li><a href="roi-ai.html">The ROI of AI Parking Enforcement</a></li>
+        </ul>
+      </aside>
+      <div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Case Study: Revenue Growth in a 45-Space Lot</div>
+        <div class="section">
+          <div class="kicker">Resources</div>
+          <h1>Case Study: Revenue Growth in a 45-Space Lot</h1>
+          <p>A downtown property owner switched from a cash box + attendant to an AI-powered enforcement system. Within 90 days:</p>
+          <ul>
+            <li>Revenue grew by 55%</li>
+            <li>Operating costs dropped to near zero</li>
+            <li>Compliance rates climbed above 90%</li>
+          </ul>
+          <p>By year’s end, the system had paid for itself twice over — while freeing the owner from manual oversight.</p>
+          <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
+        </div>
+        <footer>
+          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+        </footer>
+      </div>
     </div>
-    <footer>
-      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-    </footer>
   </main>
 </body>
 </html>

--- a/gate-arms.html
+++ b/gate-arms.html
@@ -8,6 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
+  <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
 </head>
 <body>
@@ -25,15 +26,29 @@
   </header>
 
   <main class="container">
-    <div class="section">
-      <div class="kicker">Resources</div>
-      <h1>Why Gate Arms Cost More Than They Earn</h1>
-      <p>Gate arms require costly installation, ongoing maintenance, and frequent repairs. They also slow traffic flow, leading to customer frustration. In many cases, the cost of ownership outweighs the revenue they protect.</p>
-      <p>AI enforcement eliminates these issues by allowing free-flow entry and exit while still capturing every violation and payment digitally.</p>
+    <div class="two-col">
+      <aside class="sidenav card">
+        <div class="small" style="margin-bottom:8px;font-weight:700">Related Articles</div>
+        <ul class="menu">
+          <li><a href="make-money.html">How to Make Money From Your Parking Lot</a></li>
+          <li><a href="mistakes.html">5 Common Mistakes Parking Lot Owners Make</a></li>
+          <li><a href="roi-ai.html">The ROI of AI Parking Enforcement</a></li>
+          <li><a href="case-study.html">Case Study: Revenue Growth in a 45-Space Lot</a></li>
+        </ul>
+      </aside>
+      <div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Why Gate Arms Cost More Than They Earn</div>
+        <div class="section">
+          <div class="kicker">Resources</div>
+          <h1>Why Gate Arms Cost More Than They Earn</h1>
+          <p>Gate arms require costly installation, ongoing maintenance, and frequent repairs. They also slow traffic flow, leading to customer frustration. In many cases, the cost of ownership outweighs the revenue they protect.</p>
+          <p>AI enforcement eliminates these issues by allowing free-flow entry and exit while still capturing every violation and payment digitally.</p>
+        </div>
+        <footer>
+          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+        </footer>
+      </div>
     </div>
-    <footer>
-      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-    </footer>
   </main>
 </body>
 </html>

--- a/make-money.html
+++ b/make-money.html
@@ -8,6 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
+  <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
 </head>
 <body>
@@ -25,23 +26,37 @@
   </header>
 
   <main class="container">
-    <div class="section">
-      <div class="kicker">Resources</div>
-      <h1>How to Make Money From Your Parking Lot</h1>
-      <p>Parking lots are often overlooked as investment assets, but the right approach can turn asphalt into a steady profit center. This flagship guide covers everything from monetization models and pricing strategies to enforcement and long-term ROI.</p>
-      <h2>Monetization Models</h2>
-      <p>Choose between hourly, daily, event-based, or monthly passes depending on your market. Hybrid approaches work well for mixed-demand locations.</p>
-      <h2>Pricing That Drives Occupancy</h2>
-      <p>Survey competitors, track fill rates, and experiment with dynamic pricing. AI systems can automatically adjust rates to capture peak demand while filling slow periods.</p>
-      <h2>Automated Enforcement</h2>
-      <p>Without enforcement, 20–30% of potential revenue is lost. AI-powered enforcement ensures compliance with license plate recognition, photo evidence, and online payments — no attendants or gate arms required.</p>
-      <h2>ROI Example</h2>
-      <p>A 50-space lot, priced at $5/day with 60% occupancy, makes about $4,500/month. With AI enforcement improving compliance and pricing optimization, that same lot can generate $6,000+ monthly. Over a year, that’s an $18,000+ gain.</p>
-      <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
+    <div class="two-col">
+      <aside class="sidenav card">
+        <div class="small" style="margin-bottom:8px;font-weight:700">Related Articles</div>
+        <ul class="menu">
+          <li><a href="mistakes.html">5 Common Mistakes Parking Lot Owners Make</a></li>
+          <li><a href="gate-arms.html">Why Gate Arms Cost More Than They Earn</a></li>
+          <li><a href="roi-ai.html">The ROI of AI Parking Enforcement</a></li>
+          <li><a href="case-study.html">Case Study: Revenue Growth in a 45-Space Lot</a></li>
+        </ul>
+      </aside>
+      <div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → How to Make Money From Your Parking Lot</div>
+        <div class="section">
+          <div class="kicker">Resources</div>
+          <h1>How to Make Money From Your Parking Lot</h1>
+          <p>Parking lots are often overlooked as investment assets, but the right approach can turn asphalt into a steady profit center. This flagship guide covers everything from monetization models and pricing strategies to enforcement and long-term ROI.</p>
+          <h2>Monetization Models</h2>
+          <p>Choose between hourly, daily, event-based, or monthly passes depending on your market. Hybrid approaches work well for mixed-demand locations.</p>
+          <h2>Pricing That Drives Occupancy</h2>
+          <p>Survey competitors, track fill rates, and experiment with dynamic pricing. AI systems can automatically adjust rates to capture peak demand while filling slow periods.</p>
+          <h2>Automated Enforcement</h2>
+          <p>Without enforcement, 20–30% of potential revenue is lost. AI-powered enforcement ensures compliance with license plate recognition, photo evidence, and online payments — no attendants or gate arms required.</p>
+          <h2>ROI Example</h2>
+          <p>A 50-space lot, priced at $5/day with 60% occupancy, makes about $4,500/month. With AI enforcement improving compliance and pricing optimization, that same lot can generate $6,000+ monthly. Over a year, that’s an $18,000+ gain.</p>
+          <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
+        </div>
+        <footer>
+          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+        </footer>
+      </div>
     </div>
-    <footer>
-      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-    </footer>
   </main>
 </body>
 </html>

--- a/mistakes.html
+++ b/mistakes.html
@@ -8,6 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
+  <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
 </head>
 <body>
@@ -25,20 +26,34 @@
   </header>
 
   <main class="container">
-    <div class="section">
-      <div class="kicker">Resources</div>
-      <h1>5 Common Mistakes Parking Lot Owners Make</h1>
-      <ul>
-        <li>Relying on attendants who increase costs and create inconsistencies</li>
-        <li>Using outdated gate arms that break down and frustrate drivers</li>
-        <li>Failing to enforce properly, leading to unpaid usage</li>
-        <li>Ignoring occupancy data and pricing opportunities</li>
-        <li>Delaying adoption of automation until revenue has already declined</li>
-      </ul>
+    <div class="two-col">
+      <aside class="sidenav card">
+        <div class="small" style="margin-bottom:8px;font-weight:700">Related Articles</div>
+        <ul class="menu">
+          <li><a href="make-money.html">How to Make Money From Your Parking Lot</a></li>
+          <li><a href="gate-arms.html">Why Gate Arms Cost More Than They Earn</a></li>
+          <li><a href="roi-ai.html">The ROI of AI Parking Enforcement</a></li>
+          <li><a href="case-study.html">Case Study: Revenue Growth in a 45-Space Lot</a></li>
+        </ul>
+      </aside>
+      <div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → 5 Common Mistakes Parking Lot Owners Make</div>
+        <div class="section">
+          <div class="kicker">Resources</div>
+          <h1>5 Common Mistakes Parking Lot Owners Make</h1>
+          <ul>
+            <li>Relying on attendants who increase costs and create inconsistencies</li>
+            <li>Using outdated gate arms that break down and frustrate drivers</li>
+            <li>Failing to enforce properly, leading to unpaid usage</li>
+            <li>Ignoring occupancy data and pricing opportunities</li>
+            <li>Delaying adoption of automation until revenue has already declined</li>
+          </ul>
+        </div>
+        <footer>
+          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+        </footer>
+      </div>
     </div>
-    <footer>
-      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-    </footer>
   </main>
 </body>
 </html>

--- a/roi-ai.html
+++ b/roi-ai.html
@@ -8,6 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
+  <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
 </head>
 <body>
@@ -25,14 +26,28 @@
   </header>
 
   <main class="container">
-    <div class="section">
-      <div class="kicker">Resources</div>
-      <h1>The ROI of AI Parking Enforcement</h1>
-      <p>AI solutions reduce staffing, minimize equipment overhead, and ensure higher compliance. For most lots, ROI is reached within the first 6–9 months of deployment, making automation one of the fastest ways to improve profit margins.</p>
+    <div class="two-col">
+      <aside class="sidenav card">
+        <div class="small" style="margin-bottom:8px;font-weight:700">Related Articles</div>
+        <ul class="menu">
+          <li><a href="make-money.html">How to Make Money From Your Parking Lot</a></li>
+          <li><a href="mistakes.html">5 Common Mistakes Parking Lot Owners Make</a></li>
+          <li><a href="gate-arms.html">Why Gate Arms Cost More Than They Earn</a></li>
+          <li><a href="case-study.html">Case Study: Revenue Growth in a 45-Space Lot</a></li>
+        </ul>
+      </aside>
+      <div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → The ROI of AI Parking Enforcement</div>
+        <div class="section">
+          <div class="kicker">Resources</div>
+          <h1>The ROI of AI Parking Enforcement</h1>
+          <p>AI solutions reduce staffing, minimize equipment overhead, and ensure higher compliance. For most lots, ROI is reached within the first 6–9 months of deployment, making automation one of the fastest ways to improve profit margins.</p>
+        </div>
+        <footer>
+          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+        </footer>
+      </div>
     </div>
-    <footer>
-      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-    </footer>
   </main>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,8 @@ p{margin:0 0 10px 0}
 .cta.secondary{background:#1118270d;color:var(--brand);border:1px solid var(--border)}
 .grid3{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:18px;margin-top:20px}
 .card{background:var(--card);padding:20px;border-radius:14px;box-shadow:0 6px 22px rgba(15,23,42,0.06);border:1px solid var(--border)}
+.grid3 .card{display:flex;flex-direction:column}
+.grid3 .card .cta{margin-top:auto}
 ul{padding-left:18px;margin:0 0 8px 0}
 footer{margin-top:56px;padding:28px 0;color:var(--muted);text-align:center;border-top:1px solid var(--border)}
 .small{font-size:.9375rem;color:var(--muted)}


### PR DESCRIPTION
## Summary
- add breadcrumb trail and related-articles sidebar on each resource article
- link resource articles canonically back to the resources overview
- align "Read More" buttons across resource cards

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ba3eff34832ba4fc600dc7fc9928