### PR TITLE
Enhance services page with icons and emphasis

### DIFF
--- a/services.html
+++ b/services.html
@@ -48,9 +48,9 @@
 
   <div class="services-list">
     <section id="svc-enforcement" class="service-card card">
-      <span class="pill">Core Platform</span>
-      <h2>Parking Enforcement Software</h2>
-      <p class="small">Cloud dashboard + mobile app for enforcement teams. Capture plate/violation, issue citations, accept payments, and view real‑time compliance and occupancy reports.</p>
+        <span class="pill">Core Platform</span>
+        <h2><svg xmlns="http://www.w3.org/2000/svg" class="svc-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10"/><path d="m9 12 2 2 4-4"/></svg>Parking Enforcement Software</h2>
+        <p class="small"><strong>Automated enforcement</strong> through a cloud dashboard and mobile app. Capture plate/violation, issue citations, accept payments, and view real‑time compliance and occupancy reports.</p>
       <ul>
         <li>Mobile LPR capture & photo evidence</li>
         <li>Custom violation types & workflows</li>
@@ -60,9 +60,9 @@
     <hr class="service-divider">
 
     <section id="svc-ticketing" class="service-card card">
-      <span class="pill">Automation</span>
-      <h2>Automated Ticketing</h2>
-      <p class="small">Camera and sensor options reduce manual patrols while increasing compliance. Configure grace periods, escalation rules, and dispute handling.</p>
+        <span class="pill">Automation</span>
+        <h2><svg xmlns="http://www.w3.org/2000/svg" class="svc-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v3a2 2 0 1 0 0 4v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-3a2 2 0 1 0 0-4Z"/><path d="M15 5v2"/><path d="M15 17v2"/><path d="M15 11v2"/></svg>Automated Ticketing</h2>
+        <p class="small">Camera and sensor options reduce manual patrols while increasing compliance in a <strong>ticketing system</strong>. Configure grace periods, escalation rules, and dispute handling.</p>
       <ul>
         <li>24/7 monitoring with alerts</li>
         <li>Automatic notice creation & delivery</li>
@@ -72,9 +72,9 @@
     <hr class="service-divider">
 
     <section id="svc-optimization" class="service-card card">
-      <span class="pill">Advisory</span>
-      <h2>Revenue Optimization</h2>
-      <p class="small">We analyze demand, pricing, and occupancy to create a plan tailored to your lot size and neighborhood dynamics.</p>
+        <span class="pill">Advisory</span>
+        <h2><svg xmlns="http://www.w3.org/2000/svg" class="svc-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 6l-9.5 9.5-5-5L1 17"/><path d="M17 6h6v6"/></svg>Revenue Optimization</h2>
+        <p class="small">We analyze demand, pricing, and occupancy to create a plan tailored to your lot size and neighborhood dynamics for revenue <strong>optimization</strong>.</p>
       <ul>
         <li>Pricing strategy (hourly, daily, monthly)</li>
         <li>Utilization analysis & dynamic pricing</li>
@@ -84,8 +84,8 @@
     <hr class="service-divider">
 
     <section id="svc-addons" class="service-card card">
-      <span class="pill">Add‑ons</span>
-      <h2>Add‑ons & Integrations</h2>
+        <span class="pill">Add‑ons</span>
+        <h2><svg xmlns="http://www.w3.org/2000/svg" class="svc-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22v-7"/><path d="M9 3v3"/><path d="M15 3v3"/><path d="M5 6h14"/><path d="M7 9h10v4a5 5 0 0 1-10 0V9Z"/></svg>Add‑ons & Integrations</h2>
       <ul>
         <li>Monthly pass management</li>
         <li>Event/short‑term bookings</li>

--- a/styles.css
+++ b/styles.css
@@ -74,13 +74,15 @@ footer{margin-top:56px;padding:28px 0;color:var(--muted);text-align:center;borde
 .sidenav a{display:block;padding:12px 14px;border-radius:12px;background:#f1f5f9;text-decoration:none;color:var(--ink);font-weight:600;border:1px solid var(--border)}
 .sidenav a:hover{background:#e7eef6}
 .service-card{padding:26px;margin-bottom:36px;scroll-margin-top:100px}
+.services-list .service-card:nth-of-type(even){background:var(--bg)}
 .service-divider{border:none;border-top:1px solid var(--border);margin:40px 0}
-.services-list h2{font-size:1.5rem;line-height:1.3;margin:0 0 14px 0}
+.services-list h2{font-size:1.5rem;line-height:1.3;margin:0 0 14px 0;display:flex;align-items:center;gap:8px}
 .services-list h3{font-size:1.25rem;line-height:1.3;margin:0 0 8px 0}
 .services-list p{margin:0 0 12px 0;line-height:1.6}
 .services-list ul{list-style:none;padding:0;margin:0 0 12px 0}
 .services-list li{display:flex;gap:8px;align-items:flex-start;line-height:1.6;padding:4px 0}
 .services-list li::before{content:"\2713"}
+.svc-icon{width:20px;height:20px;stroke:var(--brand);flex-shrink:0}
 .pill{display:inline-block;background:#eef2ff;border-radius:999px;padding:5px 12px;font-size:.8125rem;margin-bottom:8px;border:1px solid #e0e7ff}
 .kicker{letter-spacing:.18em;text-transform:uppercase;font-weight:700;font-size:.8125rem;color:var(--muted);margin-bottom:8px}
 .breadcrumb{font-size:.9375rem;color:var(--muted);margin:10px 0 18px 0}


### PR DESCRIPTION
## Summary
- add blue SVG icons before each services heading
- alternate service block backgrounds for easier scanning
- emphasize key phrases in service descriptions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f3771008832ba4a387c778a2c1a4