### PR TITLE
fix: add unique canonical links for article pages

### DIFF
--- a/case-study.html
+++ b/case-study.html
@@ -8,7 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
-  <link rel="canonical" href="resources.html">
+  <link rel="canonical" href="case-study.html">
   <script defer src="script.js"></script>
 </head>
 <body>

--- a/gate-arms.html
+++ b/gate-arms.html
@@ -8,7 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
-  <link rel="canonical" href="resources.html">
+  <link rel="canonical" href="gate-arms.html">
   <script defer src="script.js"></script>
 </head>
 <body>

--- a/make-money.html
+++ b/make-money.html
@@ -8,7 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
-  <link rel="canonical" href="resources.html">
+  <link rel="canonical" href="make-money.html">
   <script defer src="script.js"></script>
 </head>
 <body>

--- a/mistakes.html
+++ b/mistakes.html
@@ -8,7 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
-  <link rel="canonical" href="resources.html">
+  <link rel="canonical" href="mistakes.html">
   <script defer src="script.js"></script>
 </head>
 <body>

--- a/roi-ai.html
+++ b/roi-ai.html
@@ -8,7 +8,7 @@
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
-  <link rel="canonical" href="resources.html">
+  <link rel="canonical" href="roi-ai.html">
   <script defer src="script.js"></script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- give each article page its own canonical URL instead of pointing to resources

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f55f3204832bad4e6d80bd217671