### PR TITLE
Add structured data schema to all pages

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -9,6 +9,13 @@
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
   <script defer src="script.js"></script>
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"Organization",
+    "name":"ParkingProfit Solutions",
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
+  }</script>
 </head>
 <body>
   <header>

--- a/case-study.html
+++ b/case-study.html
@@ -10,6 +10,13 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"Organization",
+    "name":"ParkingProfit Solutions",
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
+  }</script>
 </head>
 <body>
   <header>

--- a/contact.html
+++ b/contact.html
@@ -13,8 +13,8 @@
     "@context":"https://schema.org",
     "@type":"Organization",
     "name":"ParkingProfit Solutions",
-    "url":"https://example.com",
-    "logo":"https://example.com/logo.png"
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
   }</script>
 </head>
 <body>

--- a/faq.html
+++ b/faq.html
@@ -13,8 +13,8 @@
     "@context":"https://schema.org",
     "@type":"Organization",
     "name":"ParkingProfit Solutions",
-    "url":"https://example.com",
-    "logo":"https://example.com/logo.png"
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
   }</script>
 </head>
 <body>

--- a/gate-arms.html
+++ b/gate-arms.html
@@ -10,6 +10,13 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"Organization",
+    "name":"ParkingProfit Solutions",
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
+  }</script>
 </head>
 <body>
   <header>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
   <script defer src="script.js"></script>
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"Organization",
+    "name":"ParkingProfit Solutions",
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
+  }</script>
 </head>
 <body>
   <header>

--- a/make-money.html
+++ b/make-money.html
@@ -10,6 +10,13 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"Organization",
+    "name":"ParkingProfit Solutions",
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
+  }</script>
 </head>
 <body>
   <header>

--- a/mistakes.html
+++ b/mistakes.html
@@ -10,6 +10,13 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"Organization",
+    "name":"ParkingProfit Solutions",
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
+  }</script>
 </head>
 <body>
   <header>

--- a/resources.html
+++ b/resources.html
@@ -13,8 +13,8 @@
     "@context":"https://schema.org",
     "@type":"Organization",
     "name":"ParkingProfit Solutions",
-    "url":"https://example.com",
-    "logo":"https://example.com/logo.png"
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
   }</script>
 </head>
 <body>

--- a/roi-ai.html
+++ b/roi-ai.html
@@ -10,6 +10,13 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="canonical" href="resources.html">
   <script defer src="script.js"></script>
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"Organization",
+    "name":"ParkingProfit Solutions",
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
+  }</script>
 </head>
 <body>
   <header>

--- a/services.html
+++ b/services.html
@@ -13,8 +13,8 @@
     "@context":"https://schema.org",
     "@type":"Organization",
     "name":"ParkingProfit Solutions",
-    "url":"https://example.com",
-    "logo":"https://example.com/logo.png"
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
   }</script>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add organization structured data snippet to every HTML page
- Point structured data `url` and `logo` to parkingprofit.com assets

## Testing
- `curl -s -o /tmp/rich.html -w "%{http_code}\n" 'https://search.google.com/test/rich-results?url=https://parkingprofit.com'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f57a939c832bab8471f7abf0f61b