### PR TITLE
Refactor site to use shared header and footer partials

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -11,22 +11,7 @@
   <script defer src="script.js"></script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="calculator.html" class="">Calculator</a>
-        <a href="make-money.html" class="">Make Money</a>
-        <a href="boost-profit.html" class="">Boost Profit</a>
-        <a href="ai-vs-traditional.html" class="">AI vs Traditional</a class="active">Calculator</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
 
@@ -70,9 +55,7 @@
   </div>
 </div>
 
-<footer>
-    <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-  </footer>
+  <footer id="footer"></footer>
   </main>
 </body>
 </html>

--- a/case-study.html
+++ b/case-study.html
@@ -12,18 +12,7 @@
   <script defer src="script.js"></script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="active">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
     <div class="two-col">
@@ -50,9 +39,7 @@
           <p>By year’s end, the system had paid for itself twice over — while freeing the owner from manual oversight.</p>
           <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
         </div>
-        <footer>
-          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-        </footer>
+        <footer id="footer"></footer>
       </div>
     </div>
   </main>

--- a/contact.html
+++ b/contact.html
@@ -18,18 +18,7 @@
   }</script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="contact.html" class="active">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
   
@@ -46,9 +35,7 @@
   </form>
 </div>
 
-  <footer>
-    <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-  </footer>
+  <footer id="footer"></footer>
   </main>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -18,18 +18,7 @@
   }</script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="">Resources</a>
-        <a href="faq.html" class="active">FAQ</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
   
@@ -43,9 +32,7 @@
   <p class="small">Yes. Even 10 spaces can produce meaningful income with the right pricing and compliance.</p>
 </div>
 
-  <footer>
-    <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-  </footer>
+  <footer id="footer"></footer>
   </main>
 </body>
 </html>

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,1 @@
+<div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>

--- a/gate-arms.html
+++ b/gate-arms.html
@@ -12,18 +12,7 @@
   <script defer src="script.js"></script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="active">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
     <div class="two-col">
@@ -44,9 +33,7 @@
           <p>Gate arms require costly installation, ongoing maintenance, and frequent repairs. They also slow traffic flow, leading to customer frustration. In many cases, the cost of ownership outweighs the revenue they protect.</p>
           <p>AI enforcement eliminates these issues by allowing free-flow entry and exit while still capturing every violation and payment digitally.</p>
         </div>
-        <footer>
-          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-        </footer>
+        <footer id="footer"></footer>
       </div>
     </div>
   </main>

--- a/header.html
+++ b/header.html
@@ -1,0 +1,11 @@
+<div class="container nav">
+  <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="services.html">Services</a>
+    <a href="resources.html">Resources</a>
+    <a href="faq.html">FAQ</a>
+    <a href="calculator.html">Calculator</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+</div>

--- a/index.html
+++ b/index.html
@@ -11,19 +11,7 @@
   <script defer src="script.js"></script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="active">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="calculator.html" class="">Calculator</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main>
 
@@ -66,9 +54,7 @@
       </div>
     </section>
 
-    <footer>
-      <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-    </footer>
+    <footer id="footer"></footer>
   </main>
 </body>
 </html>

--- a/make-money.html
+++ b/make-money.html
@@ -12,18 +12,7 @@
   <script defer src="script.js"></script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="active">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
     <div class="two-col">
@@ -52,9 +41,7 @@
           <p>A 50-space lot, priced at $5/day with 60% occupancy, makes about $4,500/month. With AI enforcement improving compliance and pricing optimization, that same lot can generate $6,000+ monthly. Over a year, that’s an $18,000+ gain.</p>
           <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
         </div>
-        <footer>
-          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-        </footer>
+        <footer id="footer"></footer>
       </div>
     </div>
   </main>

--- a/mistakes.html
+++ b/mistakes.html
@@ -12,18 +12,7 @@
   <script defer src="script.js"></script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="active">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
     <div class="two-col">
@@ -49,9 +38,7 @@
             <li>Delaying adoption of automation until revenue has already declined</li>
           </ul>
         </div>
-        <footer>
-          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-        </footer>
+        <footer id="footer"></footer>
       </div>
     </div>
   </main>

--- a/resources.html
+++ b/resources.html
@@ -18,18 +18,7 @@
   }</script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="active">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
     <div class="section">
@@ -66,9 +55,7 @@
       </div>
     </div>
 
-    <footer>
-      <div class="small">&copy; <span id="year"></span> ParkingProfit Solutions &mdash; Built for parking lot owners who want results.</div>
-    </footer>
+    <footer id="footer"></footer>
   </main>
 </body>
 </html>

--- a/roi-ai.html
+++ b/roi-ai.html
@@ -12,18 +12,7 @@
   <script defer src="script.js"></script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="">Services</a>
-        <a href="resources.html" class="active">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
     <div class="two-col">
@@ -43,9 +32,7 @@
           <h1>The ROI of AI Parking Enforcement</h1>
           <p>AI solutions reduce staffing, minimize equipment overhead, and ensure higher compliance. For most lots, ROI is reached within the first 6–9 months of deployment, making automation one of the fastest ways to improve profit margins.</p>
         </div>
-        <footer>
-          <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-        </footer>
+        <footer id="footer"></footer>
       </div>
     </div>
   </main>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,30 @@
 
-document.addEventListener('DOMContentLoaded', ()=>{
-  const yearEl = document.getElementById('year');
-  if (yearEl) yearEl.textContent = new Date().getFullYear();
+document.addEventListener('DOMContentLoaded', () => {
+  const load = (id, file) => {
+    const el = document.getElementById(id);
+    if (!el) return Promise.resolve();
+    return fetch(file)
+      .then(r => r.text())
+      .then(html => {
+        el.innerHTML = html;
+      });
+  };
+
+  Promise.all([
+    load('header', 'header.html'),
+    load('footer', 'footer.html')
+  ]).then(() => {
+    const path = location.pathname.split('/').pop() || 'index.html';
+    document
+      .querySelectorAll('#header nav a')
+      .forEach(link => {
+        if (link.getAttribute('href') === path) {
+          link.classList.add('active');
+        }
+      });
+    const yearEl = document.getElementById('year');
+    if (yearEl) yearEl.textContent = new Date().getFullYear();
+  });
 });
 
 function estimate(){

--- a/services.html
+++ b/services.html
@@ -18,18 +18,7 @@
   }</script>
 </head>
 <body>
-  <header>
-    <div class="container nav">
-      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
-      <nav>
-        <a href="index.html" class="">Home</a>
-        <a href="services.html" class="active">Services</a>
-        <a href="resources.html" class="">Resources</a>
-        <a href="faq.html" class="">FAQ</a>
-        <a href="contact.html" class="">Contact</a>
-      </nav>
-    </div>
-  </header>
+  <header id="header"></header>
 
   <main class="container">
   
@@ -96,9 +85,7 @@
   </div>
 </div>
 
-  <footer>
-    <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
-  </footer>
+  <footer id="footer"></footer>
   </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce `header.html` and `footer.html` partials for reusable navigation and copyright
- load partials dynamically and highlight active navigation link via JavaScript
- replace duplicated header/footer markup across all pages with the new partials

## Testing
- `curl -s http://localhost:8000/index.html | head -n 20`
- `curl -s http://localhost:8000/resources.html | sed -n '20,40p'`
- `npm install jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f586c8ec832b83db5f5a60a9ee85