### PR TITLE
Add About Us page with mission and owner panels

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>About | ParkingProfit Solutions</title>
+  <meta name="description" content="Learn more about ParkingProfit Solutions and our mission to help parking lot owners maximize revenue.">
+  <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+  <link rel="stylesheet" href="styles.css">
+  <script defer src="script.js"></script>
+  <script type="application/ld+json">{
+    "@context":"https://schema.org",
+    "@type":"Organization",
+    "name":"ParkingProfit Solutions",
+    "url":"https://parkingprofit.com",
+    "logo":"https://parkingprofit.com/logo.png"
+  }</script>
+</head>
+<body>
+  <header>
+    <div class="container nav">
+      <div class="logo">ParkingProfit<span style="color:#111827;font-weight:600"> Solutions</span></div>
+      <nav>
+        <a href="index.html" class="">Home</a>
+        <a href="services.html" class="">Services</a>
+        <a href="resources.html" class="">Resources</a>
+        <a href="faq.html" class="">FAQ</a>
+        <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="active">About</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="container">
+
+<h1>About Us</h1>
+
+<section class="card">
+  <h2>Mission Statement</h2>
+  <p class="small">[Insert mission statement here]</p>
+</section>
+
+<section class="card" style="margin-top:24px">
+  <h2>Owner Profile</h2>
+  <p class="small">[Insert owner description here]</p>
+</section>
+
+  <footer>
+    <div class="small">© <span id="year"></span> ParkingProfit Solutions — Built for parking lot owners who want results.</div>
+  </footer>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add About Us page using existing header, footer, and styling
- include mission statement and owner profile sections in card-style boxes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fa4169d0832b894759317dc4aebb