### PR TITLE
Add About page to site navigation

### DIFF
--- a/calculator.html
+++ b/calculator.html
@@ -28,6 +28,7 @@
         <a href="faq.html" class="">FAQ</a>
         <a href="calculator.html" class="active">Calculator</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/case-study.html
+++ b/case-study.html
@@ -28,6 +28,7 @@
         <a href="resources.html" class="active">Resources</a>
         <a href="faq.html" class="">FAQ</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/contact.html
+++ b/contact.html
@@ -27,6 +27,7 @@
         <a href="resources.html" class="">Resources</a>
         <a href="faq.html" class="">FAQ</a>
         <a href="contact.html" class="active">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/faq.html
+++ b/faq.html
@@ -27,6 +27,7 @@
         <a href="resources.html" class="">Resources</a>
         <a href="faq.html" class="active">FAQ</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/gate-arms.html
+++ b/gate-arms.html
@@ -28,6 +28,7 @@
         <a href="resources.html" class="active">Resources</a>
         <a href="faq.html" class="">FAQ</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
         <a href="faq.html" class="">FAQ</a>
         <a href="calculator.html" class="">Calculator</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/make-money.html
+++ b/make-money.html
@@ -28,6 +28,7 @@
         <a href="resources.html" class="active">Resources</a>
         <a href="faq.html" class="">FAQ</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/mistakes.html
+++ b/mistakes.html
@@ -28,6 +28,7 @@
         <a href="resources.html" class="active">Resources</a>
         <a href="faq.html" class="">FAQ</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/resources.html
+++ b/resources.html
@@ -27,6 +27,7 @@
         <a href="resources.html" class="active">Resources</a>
         <a href="faq.html" class="">FAQ</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/roi-ai.html
+++ b/roi-ai.html
@@ -28,6 +28,7 @@
         <a href="resources.html" class="active">Resources</a>
         <a href="faq.html" class="">FAQ</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>

--- a/services.html
+++ b/services.html
@@ -27,6 +27,7 @@
         <a href="resources.html" class="">Resources</a>
         <a href="faq.html" class="">FAQ</a>
         <a href="contact.html" class="">Contact</a>
+        <a href="about.html" class="">About</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- Include About link in header navigation across all pages
- Highlight About link as active on about.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8fe4dcb04832baee9c767ef3f9225