### PR TITLE
Add owner bio text to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,7 +45,7 @@
   <h2>Meet the Owner</h2>
   <div class="owner-content">
     <img src="https://via.placeholder.com/150" alt="Owner" class="owner-image">
-    <p class="small">[Insert owner description here]</p>
+    <p class="small">“Dax Dickson brings years of proven sales expertise to the parking industry. His background in building client relationships and guiding complex deals gives him a unique ability to understand property owners’ needs and match them with the right solutions.”</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- replace the placeholder Meet the Owner content on the About page with the provided biography for Dax Dickson

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cca1325ba0832b802300c6672cd62d