### PR TITLE
Adjust hero attribution text color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,12 @@ p{margin:0 0 10px 0}
   margin:8px auto 0;
   max-width:60ch;
 }
+.hero .small{
+  color:#fff;
+}
+.hero .small a{
+  color:#fff;
+}
 .hero-actions{
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
## Summary
- ensure the "Powered by MPS" attribution in the hero uses the standard white text color
- apply matching color to its info icon link

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cca5d7eaf4832bbaed4a0a1ca12a26