### PR TITLE
Ensure hero attribution link is white

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,12 @@
           <a class="cta" href="contact.html">Get Your Free Parking Revenue Assessment</a>
           <a class="cta secondary" href="calculator.html">Try the Parking Revenue Calculator</a>
         </div>
-        <div class="small" style="margin-top:12px">Powered by MPS <a href="https://municipalparkingservices.com" aria-label="Learn more about Municipal Parking Services" style="font-size:0.875em;text-decoration:none">ℹ️</a></div>
+        <div class="hero-attribution">
+          <a class="hero-attribution__link" href="https://municipalparkingservices.com" aria-label="Learn more about Municipal Parking Services">
+            <span>Powered by MPS</span>
+            <span aria-hidden="true">ℹ️</span>
+          </a>
+        </div>
       </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -44,6 +44,22 @@ p{margin:0 0 10px 0}
   margin:8px auto 0;
   max-width:60ch;
 }
+.hero-attribution{
+  margin-top:12px;
+  font-size:.9375rem;
+  color:#fff;
+}
+.hero-attribution__link{
+  color:#fff;
+  text-decoration:none;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+.hero-attribution__link:hover,
+.hero-attribution__link:focus-visible{
+  text-decoration:underline;
+}
 .hero-actions{
   display:flex;
   flex-direction:column;


### PR DESCRIPTION
## Summary
- convert the hero attribution into a dedicated white link for reliable contrast
- add specific styling so the attribution maintains consistent spacing and inherits the hero's white color

## Testing
- not run (static content change)

------
https://chatgpt.com/codex/tasks/task_e_68cca5d7eaf4832bbaed4a0a1ca12a26