### PR TITLE
Add About MPS panel to home

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,15 @@
       </div>
     </section>
 
+    <section class="container" style="margin-top:28px">
+      <div class="card">
+        <h2>About Municipal Parking Services (MPS)</h2>
+        <p>MPS provides AI-powered parking enforcement and analytics used by property owners and municipalities.</p>
+        <p>We implement MPS to modernize lots without gates or attendants.</p>
+        <a class="cta secondary" href="https://municipalparkingservices.com" target="_blank" rel="noopener">Visit MPS</a>
+      </div>
+    </section>
+
     <footer>
       <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>
     </footer>


### PR DESCRIPTION
## Summary
- add an "About Municipal Parking Services (MPS)" card to the home page above the footer
- include placeholder copy and a CTA button linking to the MPS site in a new tab

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d1f8e958e0832bb31f71981f668a64