### PR TITLE
Remove quotes from owner bio

### DIFF
--- a/about.html
+++ b/about.html
@@ -45,7 +45,7 @@
   <h2>Meet the Owner</h2>
   <div class="owner-content">
     <img src="https://via.placeholder.com/150" alt="Owner" class="owner-image">
-    <p class="small">“Dax Dickson brings years of proven sales expertise to the parking industry. His background in building client relationships and guiding complex deals gives him a unique ability to understand property owners’ needs and match them with the right solutions.”</p>
+    <p class="small">Dax Dickson brings years of proven sales expertise to the parking industry. His background in building client relationships and guiding complex deals gives him a unique ability to understand property owners’ needs and match them with the right solutions.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- remove the decorative quotation marks around the Meet the Owner bio on the about page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d203da8254832ba8db51355166e73e