### PR TITLE
Adjust hero styling to restore blue gradient

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -31,7 +31,7 @@ p{margin:0 0 10px 0}
 .section{margin:44px 0}
 .hero{
   position:relative;
-  background:var(--brand);
+  background:linear-gradient(135deg,#1d4ed8 0%,#2563eb 48%,#1e40af 100%);
   color:#fff;
   text-align:center;
   padding:120px 0 132px;
@@ -41,7 +41,7 @@ p{margin:0 0 10px 0}
   content:"";
   position:absolute;
   inset:0;
-  background-image:radial-gradient(circle at 18% 22%,rgba(255,255,255,0.14) 0,rgba(255,255,255,0) 58%),radial-gradient(circle at 82% 30%,rgba(255,255,255,0.12) 0,rgba(255,255,255,0) 62%),radial-gradient(circle at 50% 95%,rgba(148,163,184,0.16) 0,rgba(148,163,184,0) 65%);
+  background-image:radial-gradient(circle at 18% 22%,rgba(255,255,255,0.18) 0,rgba(255,255,255,0) 58%),radial-gradient(circle at 82% 30%,rgba(191,219,254,0.24) 0,rgba(191,219,254,0) 62%),radial-gradient(circle at 50% 95%,rgba(147,197,253,0.22) 0,rgba(147,197,253,0) 65%);
   pointer-events:none;
 }
 .hero > .container{position:relative;z-index:1}


### PR DESCRIPTION
## Summary
- update the hero background to a blue gradient for a more vivid hero section
- refresh the overlay accents to use lighter blue tones that complement the background

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5f00b1478832ba3eba34c790602dd