### PR TITLE
Enhance benefit cards with icons and balanced layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,16 +48,37 @@
     </section>
 
     <section class="container">
-      <div class="grid3" style="margin-top:24px">
-        <div class="card">
+      <div class="grid3 benefits-grid">
+        <div class="card benefit-card">
+          <div class="benefit-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M5 13l4-4 4 4 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M15 7h4v4" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M5 19h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+          </div>
           <strong>Increase Revenue</strong>
           <p class="small">Monetize every space with automated monitoring and enforcement.</p>
         </div>
-        <div class="card">
+        <div class="card benefit-card">
+          <div class="benefit-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="12" cy="12" r="8" stroke="currentColor" stroke-width="2"/>
+              <path d="M12 8v4l2.5 2.5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
           <strong>Save Time</strong>
           <p class="small">Let the system handle ticketing and tracking while you focus on other things.</p>
         </div>
-        <div class="card">
+        <div class="card benefit-card">
+          <div class="benefit-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M8 4h8v3a4 4 0 01-4 4 4 4 0 01-4-4V4z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+              <path d="M6 4h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+              <path d="M9 13h6l-.8 6H9.8L9 13z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+              <path d="M9 17h6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+            </svg>
+          </div>
           <strong>Proven Results</strong>
           <p class="small">Owners report consistent revenue growth within months of setup.</p>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,10 @@ p{margin:0 0 10px 0}
 .card{background:var(--card);padding:20px;border-radius:14px;box-shadow:0 6px 22px rgba(15,23,42,0.06);border:1px solid var(--border)}
 .grid3 .card{display:flex;flex-direction:column}
 .grid3 .card .cta{margin-top:auto}
+.benefits-grid{gap:24px;margin-top:28px}
+.benefit-card{padding:28px 26px;text-align:center;align-items:center;gap:14px}
+.benefit-icon{width:56px;height:56px;border-radius:50%;background:rgba(11,110,253,0.12);color:var(--brand);display:flex;align-items:center;justify-content:center;margin-bottom:6px}
+.benefit-icon svg{width:28px;height:28px}
 ul{padding-left:18px;margin:0 0 8px 0}
 footer{margin-top:56px;padding:28px 0;color:var(--muted);text-align:center;border-top:1px solid var(--border)}
 .small{font-size:.9375rem;color:var(--muted)}


### PR DESCRIPTION
## Summary
- add benefit card icons and refreshed layout spacing for the hero benefits section
- center and balance benefit cards with consistent padding for visual alignment

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5f1025a8c832b871b9c32b00e7083