### PR TITLE
Center MPS attribution under hero buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
           <a class="cta" href="contact.html">Get Your Free Parking Revenue Assessment</a>
           <a class="cta secondary" href="calculator.html">Try the Parking Revenue Calculator</a>
         </div>
-        <div class="small">Powered by MPS <a href="https://municipalparkingservices.com" aria-label="Learn more about Municipal Parking Services" style="font-size:0.875em;text-decoration:none">ℹ️</a></div>
+        <div class="small hero-powered-by">Powered by <a href="https://municipalparkingservices.com" aria-label="Learn more about Municipal Parking Services">MPS</a></div>
       </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -71,8 +71,16 @@ section> * + *{margin-top:var(--space-block)}
   color:#fff;
   margin-top:1rem;
 }
+.hero-powered-by{
+  margin:1.25rem auto 0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:0.4rem;
+}
 .hero .small a{
   color:#fff;
+  text-decoration:underline;
 }
 .hero-actions{
   display:flex;


### PR DESCRIPTION
## Summary
- center the MPS attribution copy beneath the hero call-to-action buttons
- remove the info icon and make the MPS text itself the link

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5f84c3e0c832baf45ebda26df3d11