### PR TITLE
Homepage hero headline line break redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 
     <section class="hero">
       <div class="container">
-        <h1 class="headline">Stop Losing Parking Revenue. Upgrade to Automated AI Enforcement Today.</h1>
+        <h1 class="headline">Stop Losing Parking Revenue<br>Upgrade to Automated AI Enforcement Today</h1>
         <p class="sub">Most parking lot owners are sitting on untapped income. We make it easy with automated enforcement, proven revenue strategies, and full support. We implement AI-powered enforcement using Municipal Parking Services (MPS) technology.</p>
         <div class="hero-actions">
           <a class="cta" href="contact.html">Get Your Free Parking Revenue Assessment</a>


### PR DESCRIPTION
## Summary
- split the homepage hero headline into two lines with a manual line break to improve layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0413318b4832bbb706fe2360df511