### PR TITLE
Add CTA section below About MPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,15 @@
       </div>
     </section>
 
+    <!-- CTA: placed directly after About MPS -->
+    <section id="cta" class="section">
+      <div class="container">
+        <h2>Turn Your Parking Lot Into a Proven Profit Center</h2>
+        <p>Talk with our team and discover how MPS simplifies operations and boosts revenue.</p>
+        <a href="#contact" class="btn-primary">Get Started Today</a>
+      </div>
+    </section>
+
     <footer>
       <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>
     </footer>


### PR DESCRIPTION
## Summary
- insert a CTA section immediately after the About MPS content on the home page
- encourage visitors to contact the team with clear heading, copy, and primary button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1515338c8832bb4a2f690d2566fe4