### PR TITLE
Update hero section messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,15 +35,11 @@
 
   <main>
 
-    <section class="hero">
-      <div class="container">
-        <h1 class="headline">Stop Losing Parking Revenue<br>Upgrade to Automated AI Enforcement Today</h1>
-        <p class="sub">Most parking lot owners are sitting on untapped income. We make it easy with automated enforcement, proven revenue strategies, and full support. We implement AI-powered enforcement using Municipal Parking Services (MPS) technology.</p>
-        <div class="hero-actions">
-          <a class="cta" href="contact.html">Get Your Free Parking Revenue Assessment</a>
-          <a class="cta secondary" href="calculator.html">Try the Parking Revenue Calculator</a>
-        </div>
-        <div class="small hero-powered-by">Powered by <a href="https://municipalparkingservices.com" aria-label="Learn more about Municipal Parking Services">MPS</a></div>
+    <section id="hero" class="hero">
+      <div class="container hero__content">
+        <h1>Partner with MPS to Automate and Monetize Your Parking Lot</h1>
+        <p>We help property owners deploy MPS technology to reduce enforcement headaches and unlock new monthly income.</p>
+        <a href="#contact" class="btn-primary">Get Started Today</a>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- replace the homepage hero headline, description, and CTA with new messaging and link to the contact section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e155202ed8832bbff9027b4e351fef