### PR TITLE
Update About MPS section with card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,22 +112,16 @@
       </div>
     </section>
 
+    <!-- About MPS (white card) -->
     <section id="about" class="section">
-      <div class="container text-center">
-        <h2>About MPS</h2>
-        <p class="subhead">Partnering with the nation’s leader in AI-powered parking enforcement and automation.</p>
-        <p>Municipal Parking Services (MPS) is a proven innovator in automated parking enforcement and license-plate recognition technology. For more than a decade, MPS has helped property owners, universities, and municipalities simplify operations and turn parking into a dependable source of revenue. As a trusted partner, our team connects property owners with MPS’s advanced solutions—combining automation, real-time analytics, and 24/7 AI enforcement to deliver consistent results without extra staff, expensive hardware, or complex IT setup.</p>
-        <p><em>Let’s explore how MPS technology can help you earn more from your property.</em></p>
-        <a href="#contact" class="btn-primary">Get Started Today</a>
-      </div>
-    </section>
-
-    <!-- CTA: placed directly after About MPS -->
-    <section id="cta" class="section">
       <div class="container">
-        <h2>Turn Your Parking Lot Into a Proven Profit Center</h2>
-        <p>Talk with our team and discover how MPS simplifies operations and boosts revenue.</p>
-        <a href="#contact" class="btn-primary">Get Started Today</a>
+        <div class="card about-card text-center">
+          <h2>About MPS</h2>
+          <p class="subhead">Partnering with the nation’s leader in AI-powered parking enforcement and automation.</p>
+          <p>Municipal Parking Services (MPS) is a proven innovator in automated parking enforcement and license-plate recognition technology. For more than a decade, MPS has helped property owners, universities, and municipalities simplify operations and turn parking into a dependable source of revenue. As a trusted partner, our team connects property owners with MPS’s advanced solutions—combining automation, real-time analytics, and 24/7 AI enforcement to deliver consistent results without extra staff, expensive hardware, or complex IT setup.</p>
+          <p><em>Let’s explore how MPS technology can help you earn more from your property.</em></p>
+          <a href="#contact" class="btn-primary">Get Started Today</a>
+        </div>
       </div>
     </section>
 

--- a/styles.css
+++ b/styles.css
@@ -170,3 +170,25 @@ html{scroll-behavior:smooth}
 @media(max-width:600px){
   .owner-content{flex-direction:column;text-align:center}
 }
+
+/* Card container for About MPS */
+.card.about-card {
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.06);
+  padding: 32px 28px;
+  margin: 0 auto;
+  max-width: 920px;
+}
+.about-card h2 { margin-bottom: 8px; }
+.about-card .subhead {
+  margin-bottom: 14px;
+  opacity: 0.85;
+}
+.about-card p { margin: 0 0 16px 0; }
+.about-card .btn-primary { margin-top: 6px; }
+
+/* Mobile tweaks */
+@media (max-width: 640px) {
+  .card.about-card { padding: 24px 18px; border-radius: 12px; }
+}


### PR DESCRIPTION
## Summary
- restyle the About MPS block as a centered card with inline CTA button
- remove the redundant CTA section that followed the About content
- add dedicated about-card styles, including mobile padding adjustments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e15c14b530832bb34516094c5e8887