### PR TITLE
Remove MPS sentence from services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -48,7 +48,6 @@
   </aside>
 
   <div class="services-list">
-    <p class="small">Our solutions are delivered on Municipal Parking Services (MPS), an AI-driven platform for automated enforcement, ticketing, and reporting.</p>
     <section id="svc-enforcement" class="service-card card">
         <span class="pill">Core Platform</span>
         <h2><svg xmlns="http://www.w3.org/2000/svg" class="svc-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10"/><path d="m9 12 2 2 4-4"/></svg>Parking Enforcement Software</h2>


### PR DESCRIPTION
## Summary
- remove the introductory sentence referencing MPS from the services page content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e16c8168d4832b923d25cbd61d2554