### PR TITLE
Add consultation call-to-action styling to resources page

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -37,6 +37,20 @@
       <div class="kicker">Resources</div>
       <h1>Parking Lot Owner Resources &amp; Guides</h1>
       <p class="sub">Guides for lot owners evaluating a switch to AI enforcement with Municipal Parking Services (MPS).</p>
+      <div class="resource-actions">
+        <a class="resource-action" href="make-money.html">
+          <span class="resource-action-title">Parking Revenue Playbook (PDF)</span>
+          <span class="small">Step-by-step strategies to monetize your lot with automated enforcement.</span>
+        </a>
+        <a class="resource-action" href="calculator.html">
+          <span class="resource-action-title">Parking Revenue Calculator</span>
+          <span class="small">Estimate gross monthly income using your space count, occupancy, and rates.</span>
+        </a>
+        <a class="resource-action" href="contact.html">
+          <span class="resource-action-title">Book a Free Consultation</span>
+          <span class="small">Talk with ParkingProfit Solutions about automating enforcement for your property.</span>
+        </a>
+      </div>
     </section>
 
     <section>

--- a/styles.css
+++ b/styles.css
@@ -137,6 +137,10 @@ li{max-width:var(--max-text)}
 .card{background:var(--card);padding:clamp(1.5rem,3vw,2.5rem);border-radius:14px;box-shadow:0 6px 22px rgba(15,23,42,0.06);border:1px solid var(--border)}
 .grid3 .card{display:flex;flex-direction:column}
 .grid3 .card .cta{margin-top:auto}
+.resource-actions{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:20px;margin-top:var(--space-block)}
+.resource-action{background:var(--card);border:1px solid var(--border);border-radius:14px;box-shadow:0 6px 22px rgba(15,23,42,0.06);padding:clamp(1.35rem,2.8vw,2.25rem);text-decoration:none;color:inherit;display:flex;flex-direction:column;min-height:100%}
+.resource-action > * + *{margin-top:0.5rem}
+.resource-action-title{font-size:1.125rem;font-weight:700;line-height:1.35}
 .timeline{display:flex;flex-direction:column;gap:var(--space-block);margin-top:var(--space-block)}
 .timeline-step{display:grid;grid-template-columns:56px 1fr;align-items:start;gap:24px;padding:16px 0;border-top:1px solid rgba(15,23,42,0.1)}
 .timeline-step:first-child{border-top:none;padding-top:0}


### PR DESCRIPTION
## Summary
- add a resource action strip to the resources page with quick links to the playbook, calculator, and consultation
- style the new resource action cards so the “Book a Free Consultation” item matches the size and typography of the other quick links

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e1ba1610b0832ba6ca115bfd3ee4c1