### PR TITLE
Remove MPS reference from services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -35,7 +35,7 @@
   <main class="container">
   
 <h1>Services</h1>
-<p class="sub">Our solutions run on Municipal Parking Services MPS, an AI driven platform for automated enforcement, ticketing, reporting, and payments.</p>
+
 <div class="two-col">
   <aside class="sidenav card">
     <div class="small aside-heading">Explore Services</div>


### PR DESCRIPTION
## Summary
- remove the introductory subheading referencing Municipal Parking Services from the services page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1ba33a9a8832b9f2dab56fb734068