### PR TITLE
Replace resources articles with placeholder content

### DIFF
--- a/case-study.html
+++ b/case-study.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Case Study: Revenue Growth in a 45 Space Lot | ParkingProfit Solutions</title>
-  <meta name="description" content="See how a 45 space parking lot boosted revenue by 55% and cut costs after adopting AI powered enforcement.">
+  <title>Article 5 | ParkingProfit Solutions</title>
+  <meta name="description" content="Placeholder content for Article 5.">
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
@@ -38,25 +38,18 @@
       <aside class="sidenav card">
         <div class="small aside-heading">Related Articles</div>
         <ul class="menu">
-          <li><a href="make-money.html">How to Make Money From Your Parking Lot</a></li>
-          <li><a href="mistakes.html">5 Common Mistakes Parking Lot Owners Make</a></li>
-          <li><a href="gate-arms.html">Why Gate Arms Cost More Than They Earn</a></li>
-          <li><a href="roi-ai.html">The ROI of AI Parking Enforcement</a></li>
+          <li><a href="make-money.html">Article 1</a></li>
+          <li><a href="mistakes.html">Article 2</a></li>
+          <li><a href="gate-arms.html">Article 3</a></li>
+          <li><a href="roi-ai.html">Article 4</a></li>
         </ul>
       </aside>
       <div>
-        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Case Study: Revenue Growth in a 45 Space Lot</div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Article 5</div>
         <section>
           <div class="kicker">Resources</div>
-          <h1>Case Study: Revenue Growth in a 45 Space Lot</h1>
-          <p>A downtown property owner switched from a cash box + attendant to an AI powered enforcement system. Within 90 days:</p>
-          <ul>
-            <li>Revenue grew by 55%</li>
-            <li>Operating costs dropped to near zero</li>
-            <li>Compliance rates climbed above 90%</li>
-          </ul>
-          <p>By year’s end, the system had paid for itself twice over, freeing the owner from manual oversight.</p>
-          <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
+          <h1>Article 5</h1>
+          <p>insert text</p>
         </section>
         <footer>
           <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>

--- a/gate-arms.html
+++ b/gate-arms.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Why Gate Arms Cost More Than They Earn | ParkingProfit Solutions</title>
-  <meta name="description" content="Gate arms add installation and maintenance costs while frustrating drivers. See why AI enforcement is a better solution.">
+  <title>Article 3 | ParkingProfit Solutions</title>
+  <meta name="description" content="Placeholder content for Article 3.">
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
@@ -38,19 +38,18 @@
       <aside class="sidenav card">
         <div class="small aside-heading">Related Articles</div>
         <ul class="menu">
-          <li><a href="make-money.html">How to Make Money From Your Parking Lot</a></li>
-          <li><a href="mistakes.html">5 Common Mistakes Parking Lot Owners Make</a></li>
-          <li><a href="roi-ai.html">The ROI of AI Parking Enforcement</a></li>
-          <li><a href="case-study.html">Case Study: Revenue Growth in a 45 Space Lot</a></li>
+          <li><a href="make-money.html">Article 1</a></li>
+          <li><a href="mistakes.html">Article 2</a></li>
+          <li><a href="roi-ai.html">Article 4</a></li>
+          <li><a href="case-study.html">Article 5</a></li>
         </ul>
       </aside>
       <div>
-        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Why Gate Arms Cost More Than They Earn</div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Article 3</div>
         <section>
           <div class="kicker">Resources</div>
-          <h1>Why Gate Arms Cost More Than They Earn</h1>
-          <p>Gate arms require costly installation, ongoing maintenance, and frequent repairs. They also slow traffic flow, leading to customer frustration. In many cases, the cost of ownership outweighs the revenue they protect.</p>
-          <p>AI enforcement eliminates these issues by allowing free flow entry and exit while still capturing every violation and payment digitally.</p>
+          <h1>Article 3</h1>
+          <p>insert text</p>
         </section>
         <footer>
           <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>

--- a/make-money.html
+++ b/make-money.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>How to Make Money From Your Parking Lot | ParkingProfit Solutions</title>
-  <meta name="description" content="Learn monetization models, pricing strategies, and enforcement tips to make money from your parking lot.">
+  <title>Article 1 | ParkingProfit Solutions</title>
+  <meta name="description" content="Placeholder content for Article 1.">
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
@@ -38,27 +38,18 @@
       <aside class="sidenav card">
         <div class="small aside-heading">Related Articles</div>
         <ul class="menu">
-          <li><a href="mistakes.html">5 Common Mistakes Parking Lot Owners Make</a></li>
-          <li><a href="gate-arms.html">Why Gate Arms Cost More Than They Earn</a></li>
-          <li><a href="roi-ai.html">The ROI of AI Parking Enforcement</a></li>
-          <li><a href="case-study.html">Case Study: Revenue Growth in a 45 Space Lot</a></li>
+          <li><a href="mistakes.html">Article 2</a></li>
+          <li><a href="gate-arms.html">Article 3</a></li>
+          <li><a href="roi-ai.html">Article 4</a></li>
+          <li><a href="case-study.html">Article 5</a></li>
         </ul>
       </aside>
       <div>
-        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → How to Make Money From Your Parking Lot</div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Article 1</div>
         <section>
           <div class="kicker">Resources</div>
-          <h1>How to Make Money From Your Parking Lot</h1>
-          <p>Parking lots are often overlooked as investment assets, but the right approach can turn asphalt into a steady profit center. This flagship guide covers everything from monetization models and pricing strategies to enforcement and long term ROI.</p>
-          <h2>Monetization Models</h2>
-          <p>Choose between hourly, daily, event based, or monthly passes depending on your market. Hybrid approaches work well for mixed demand locations.</p>
-          <h2>Pricing That Drives Occupancy</h2>
-          <p>Survey competitors, track fill rates, and experiment with dynamic pricing. AI systems can automatically adjust rates to capture peak demand while filling slow periods.</p>
-          <h2>Automated Enforcement</h2>
-          <p>Without enforcement, 20–30% of potential revenue is lost. AI powered enforcement ensures compliance with license plate recognition, photo evidence, and online payments with no attendants or gate arms required.</p>
-          <h2>ROI Example</h2>
-          <p>A 50 space lot, priced at $5/day with 60% occupancy, makes about $4,500/month. With AI enforcement improving compliance and pricing optimization, that same lot can generate $6,000+ monthly. Over a year, that’s an $18,000+ gain.</p>
-          <p><a class="cta" href="contact.html">See Your AI Revenue Potential</a></p>
+          <h1>Article 1</h1>
+          <p>insert text</p>
         </section>
         <footer>
           <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>

--- a/mistakes.html
+++ b/mistakes.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>5 Common Mistakes Parking Lot Owners Make | ParkingProfit Solutions</title>
-  <meta name="description" content="Avoid revenue loss by learning the top mistakes parking lot owners make, from poor enforcement to ignoring pricing data.">
+  <title>Article 2 | ParkingProfit Solutions</title>
+  <meta name="description" content="Placeholder content for Article 2.">
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
@@ -38,24 +38,18 @@
       <aside class="sidenav card">
         <div class="small aside-heading">Related Articles</div>
         <ul class="menu">
-          <li><a href="make-money.html">How to Make Money From Your Parking Lot</a></li>
-          <li><a href="gate-arms.html">Why Gate Arms Cost More Than They Earn</a></li>
-          <li><a href="roi-ai.html">The ROI of AI Parking Enforcement</a></li>
-          <li><a href="case-study.html">Case Study: Revenue Growth in a 45 Space Lot</a></li>
+          <li><a href="make-money.html">Article 1</a></li>
+          <li><a href="gate-arms.html">Article 3</a></li>
+          <li><a href="roi-ai.html">Article 4</a></li>
+          <li><a href="case-study.html">Article 5</a></li>
         </ul>
       </aside>
       <div>
-        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → 5 Common Mistakes Parking Lot Owners Make</div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Article 2</div>
         <section>
           <div class="kicker">Resources</div>
-          <h1>5 Common Mistakes Parking Lot Owners Make</h1>
-          <ul>
-            <li>Relying on attendants who increase costs and create inconsistencies</li>
-            <li>Using outdated gate arms that break down and frustrate drivers</li>
-            <li>Failing to enforce properly, leading to unpaid usage</li>
-            <li>Ignoring occupancy data and pricing opportunities</li>
-            <li>Delaying adoption of automation until revenue has already declined</li>
-          </ul>
+          <h1>Article 2</h1>
+          <p>insert text</p>
         </section>
         <footer>
           <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>

--- a/resources.html
+++ b/resources.html
@@ -42,33 +42,33 @@
     <section>
       <div class="grid3">
         <div class="card">
-          <h3>How to Make Money From Your Parking Lot</h3>
-          <p class="small">Turn your asphalt into a profit center with smart pricing, monetization models, and AI enforcement.</p>
-          <p class="small">This article discusses outcomes achievable with MPS-powered automation.</p>
+          <h3>Article 1</h3>
+          <p class="small">Details coming soon.</p>
+          <p class="small">Stay tuned for the full article.</p>
           <a class="cta secondary" href="make-money.html">Read More</a>
       </div>
       <div class="card">
-        <h3>5 Common Mistakes Parking Lot Owners Make</h3>
-        <p class="small">Avoid revenue draining missteps like outdated gate arms and inconsistent enforcement.</p>
-        <p class="small">This article discusses outcomes achievable with MPS-powered automation.</p>
+        <h3>Article 2</h3>
+        <p class="small">Details coming soon.</p>
+        <p class="small">Stay tuned for the full article.</p>
         <a class="cta secondary" href="mistakes.html">Read More</a>
       </div>
       <div class="card">
-        <h3>Why Gate Arms Cost More Than They Earn</h3>
-        <p class="small">Physical barriers are expensive and slow traffic. See why AI enforcement is a better investment.</p>
-        <p class="small">This article discusses outcomes achievable with MPS-powered automation.</p>
+        <h3>Article 3</h3>
+        <p class="small">Details coming soon.</p>
+        <p class="small">Stay tuned for the full article.</p>
         <a class="cta secondary" href="gate-arms.html">Read More</a>
       </div>
       <div class="card">
-        <h3>The ROI of AI Parking Enforcement</h3>
-        <p class="small">AI automation delivers quick payback by cutting costs and boosting compliance.</p>
-        <p class="small">This article discusses outcomes achievable with MPS-powered automation.</p>
+        <h3>Article 4</h3>
+        <p class="small">Details coming soon.</p>
+        <p class="small">Stay tuned for the full article.</p>
         <a class="cta secondary" href="roi-ai.html">Read More</a>
       </div>
         <div class="card">
-          <h3>Case Study: Revenue Growth in a 45 Space Lot</h3>
-          <p class="small">See how one owner increased revenue by 55% after adopting AI enforcement.</p>
-          <p class="small">This article discusses outcomes achievable with MPS-powered automation.</p>
+          <h3>Article 5</h3>
+          <p class="small">Details coming soon.</p>
+          <p class="small">Stay tuned for the full article.</p>
           <a class="cta secondary" href="case-study.html">Read More</a>
         </div>
       </div>

--- a/roi-ai.html
+++ b/roi-ai.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>The ROI of AI Parking Enforcement | ParkingProfit Solutions</title>
-  <meta name="description" content="AI parking enforcement reduces staffing and equipment costs while improving compliance, delivering ROI within months.">
+  <title>Article 4 | ParkingProfit Solutions</title>
+  <meta name="description" content="Placeholder content for Article 4.">
   <meta name="keywords" content="make money parking lot, monetize parking lot, parking enforcement software, parking revenue">
   <link rel="icon" href="data:;base64,iVBORw0KGgo=">
   <link rel="stylesheet" href="styles.css">
@@ -38,18 +38,18 @@
       <aside class="sidenav card">
         <div class="small aside-heading">Related Articles</div>
         <ul class="menu">
-          <li><a href="make-money.html">How to Make Money From Your Parking Lot</a></li>
-          <li><a href="mistakes.html">5 Common Mistakes Parking Lot Owners Make</a></li>
-          <li><a href="gate-arms.html">Why Gate Arms Cost More Than They Earn</a></li>
-          <li><a href="case-study.html">Case Study: Revenue Growth in a 45 Space Lot</a></li>
+          <li><a href="make-money.html">Article 1</a></li>
+          <li><a href="mistakes.html">Article 2</a></li>
+          <li><a href="gate-arms.html">Article 3</a></li>
+          <li><a href="case-study.html">Article 5</a></li>
         </ul>
       </aside>
       <div>
-        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → The ROI of AI Parking Enforcement</div>
+        <div class="breadcrumb"><a href="index.html">Home</a> → <a href="resources.html">Resources</a> → Article 4</div>
         <section>
           <div class="kicker">Resources</div>
-          <h1>The ROI of AI Parking Enforcement</h1>
-          <p>AI solutions reduce staffing, minimize equipment overhead, and ensure higher compliance. For most lots, ROI is reached within the first 6–9 months of deployment, making automation one of the fastest ways to improve profit margins.</p>
+          <h1>Article 4</h1>
+          <p>insert text</p>
         </section>
         <footer>
           <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>


### PR DESCRIPTION
## Summary
- replace the resource listing with placeholder article titles and copy
- update each article page to use placeholder metadata and "insert text" body content

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e4474266ec832bb1a2c3cc6dd319cf