### PR TITLE
Revamp About page content and styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,26 +32,64 @@
     </div>
   </header>
 
-  <main class="container">
+  <main>
 
-<h1>About Us</h1>
+    <section class="about-hero">
+      <div class="container">
+        <h2>About ParkingProfit Solutions</h2>
+        <p>Empowering parking lot owners with technology that increases revenue, reduces workload, and simplifies operations.</p>
+      </div>
+    </section>
 
-<section class="card">
-  <h2>Our Mission</h2>
-  <p class="small">To replace outdated gates, kiosks, and manual enforcement with seamless, AI-powered solutions that make parking management simple, profitable, and stress-free for property owners everywhere.</p>
-</section>
+    <section class="about-mission">
+      <div class="container mission-card">
+        <h2>Our Mission</h2>
+        <p>To help parking lot owners unlock new revenue and free up valuable time.</p>
+        <p>Our AI powered system replaces outdated kiosks and gates with a simple, automated platform built to grow with your business.</p>
+      </div>
+    </section>
 
-<section class="card owner-card">
-  <h2>Meet the Owner</h2>
-  <div class="owner-content">
-    <img src="https://via.placeholder.com/150" alt="Owner" class="owner-image">
-    <p class="small">Dax Dickson brings years of proven sales expertise to the parking industry. His background in building client relationships and guiding complex deals gives him a unique ability to understand property owners’ needs and match them with the right solutions.</p>
-  </div>
-</section>
+    <section class="about-owners">
+      <div class="container">
+        <h2>Meet the Owners</h2>
+        <div class="owners-grid">
+          <div class="owner-card">
+            <img src="images/dax.jpg" alt="Dax Dickson" class="owner-photo" />
+            <h3>Dax Dickson</h3>
+            <p>Dax brings years of proven sales expertise to the parking industry. His background in building client relationships and guiding complex deals gives him a unique ability to understand property owners’ needs and match them with the right solutions.</p>
+          </div>
+          <div class="owner-card">
+            <img src="images/dave.jpg" alt="Dave Wickiser" class="owner-photo" />
+            <h3>Dave Wickiser</h3>
+            <p>Dave’s experience in real estate gives property owners confidence that every partnership is structured for success. He combines deep market knowledge with a practical, results oriented mindset to help close deals efficiently and ensure each project meets the owner’s goals.</p>
+          </div>
+        </div>
+      </div>
+    </section>
 
-  <footer>
-    <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>
-  </footer>
+    <section class="about-trust">
+      <div class="container">
+        <h2>Why Owners Trust ParkingProfit Solutions</h2>
+        <ul class="trust-list">
+          <li>Proven results across private and commercial properties</li>
+          <li>No costly kiosks, gates, or complex IT setup</li>
+          <li>24/7 AI enforcement and reporting</li>
+          <li>Backed by a dedicated support team that understands your business</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="about-cta">
+      <div class="container cta-box">
+        <h2>Ready to Automate Your Lot?</h2>
+        <p>Let our team show you how easy it is to start earning more with AI powered enforcement.</p>
+        <a href="contact.html" class="btn-primary">Book a Free Consultation</a>
+      </div>
+    </section>
+
+    <footer>
+      <div class="small">© <span id="year"></span> ParkingProfit Solutions - Built for parking lot owners who want results.</div>
+    </footer>
   </main>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -289,3 +289,11 @@ html{scroll-behavior:smooth}
 @media (max-width: 640px) {
   .services-subnav__inner { justify-content: flex-start; overflow-x: auto; padding: 10px 12px; }
 }
+.about-hero, .about-mission, .about-owners, .about-trust, .about-cta { margin-bottom: 60px; }
+.mission-card { background: #f8fafc; padding: 40px; border-radius: 16px; text-align: center; }
+.owners-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 40px; margin-top: 30px; }
+.owner-card { background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); text-align: center; }
+.owner-photo { width: 140px; height: 140px; border-radius: 50%; object-fit: cover; margin-bottom: 16px; }
+.trust-list { list-style: none; padding: 0; display: grid; gap: 12px; margin-top: 20px; }
+.trust-list li::before { content: "✓ "; color: #0284c7; font-weight: bold; }
+.cta-box { background: #e0f2fe; text-align: center; padding: 50px; border-radius: 16px; }


### PR DESCRIPTION
## Summary
- replace the About page content with new hero, mission, owners, trust, and CTA sections
- add modernized layout styles for the updated About page components

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e447965bdc832b8fb6011724ce8cda