### PR TITLE
Streamline About page mission section

### DIFF
--- a/about.html
+++ b/about.html
@@ -34,16 +34,9 @@
 
   <main>
 
-    <section class="about-hero">
-      <div class="container">
-        <h2>About ParkingProfit Solutions</h2>
-        <p>Empowering parking lot owners with technology that increases revenue, reduces workload, and simplifies operations.</p>
-      </div>
-    </section>
-
     <section class="about-mission">
-      <div class="container mission-card">
-        <h2>Our Mission</h2>
+      <div class="container">
+        <h1>Our Mission</h1>
         <p>To help parking lot owners unlock new revenue and free up valuable time.</p>
         <p>Our AI powered system replaces outdated kiosks and gates with a simple, automated platform built to grow with your business.</p>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -312,7 +312,18 @@ html{scroll-behavior:smooth}
   .services-subnav__inner { justify-content: flex-start; overflow-x: auto; padding: 10px 12px; }
 }
 .about-hero, .about-mission, .about-owners, .about-trust, .about-cta { margin-bottom: 60px; }
-.mission-card { background: #f8fafc; padding: 40px; border-radius: 16px; text-align: center; }
+.about-mission {
+  text-align: center;
+  padding-top: 3rem;
+  padding-bottom: 2.5rem;
+}
+
+.about-mission p {
+  max-width: 740px;
+  margin: 0.75rem auto;
+  line-height: 1.6;
+  opacity: 0.9;
+}
 .owners-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 40px; margin-top: 30px; }
 .owner-card { background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.05); text-align: center; }
 .owner-photo { width: 140px; height: 140px; border-radius: 50%; object-fit: cover; margin-bottom: 16px; }


### PR DESCRIPTION
## Summary
- remove the introductory About hero block so the mission statement leads the page
- promote "Our Mission" to an H1 to match the Services header styling and center it beneath the nav
- tighten mission paragraph spacing with refined typography for better flow into the owners section

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e44bfda5bc832b9b4944ea42ee5a3d