### PR TITLE
Align resources header with services layout

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -36,6 +36,7 @@
     <section class="resources-header section">
       <div class="container">
         <h1>Resources</h1>
+        <!-- Keep your existing subhead text; do not change copy -->
         <p class="subhead">Guides for lot owners evaluating a switch to AI enforcement with Municipal Parking Services (MPS).</p>
       </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -385,3 +385,24 @@ html{scroll-behavior:smooth}
   opacity: 0.9;
   max-width: 780px;
 }
+
+/* Match Services header alignment */
+.resources-header.section { padding: 4rem 0 2.5rem; }
+.resources-header .container { text-align: left; }
+.resources-header h1 {
+  font-size: 3.25rem;   /* same as Services/About */
+  font-weight: 800;
+  color: #0f172a;
+  margin: 0 0 .5rem 0;
+}
+
+/* Override global paragraph centering for this header */
+.resources-header .container > p,
+.resources-header .subhead {
+  max-width: 740px;
+  margin-left: 0;
+  margin-right: 0;
+  line-height: 1.6;
+  opacity: .9;
+  color: #334155;
+}


### PR DESCRIPTION
## Summary
- align the Resources hero markup with the standard container treatment used on Services
- add CSS overrides so the Resources headline and subhead are left-aligned like Services

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4520eb7e4832ba8da63fb2e7c9f42