### PR TITLE
Add Google Ads conversion tracking to thank you page

### DIFF
--- a/consultation/thank-you/index.html
+++ b/consultation/thank-you/index.html
@@ -31,6 +31,15 @@
     gtag('config', 'AW-18066534348');
   </script>
 
+  <!-- Event snippet for Submit lead form conversion page -->
+  <script>
+    gtag('event', 'conversion', {
+      'send_to': 'AW-18066534348/dpBlCNapw5YcEMzf5aZD',
+      'value': 1.0,
+      'currency': 'USD'
+    });
+  </script>
+
   <style>
     *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 


### PR DESCRIPTION
## Summary
Added Google Ads conversion event tracking to the consultation thank you page to measure lead form submissions.

## Key Changes
- Added Google Ads conversion event snippet that fires on the thank you page
- Configured conversion tracking with:
  - Conversion ID: `AW-18066534348/dpBlCNapw5YcEMzf5aZD`
  - Fixed value of 1.0 USD per conversion
  - Proper event naming following Google Ads standards

## Implementation Details
The conversion tracking script is placed after the Google Analytics configuration tag to ensure proper initialization. This allows Google Ads to track when users reach the thank you page, indicating a successful lead form submission. The conversion value is set to 1.0 USD as a standard metric for lead generation campaigns.

https://claude.ai/code/session_01G77bPVnvNiGDgM531u5NoN