### PR TITLE
Add Calendly scheduling widget and improve CTA links

### DIFF
--- a/consultation/index.html
+++ b/consultation/index.html
@@ -576,6 +576,57 @@
     }
     .lp-footer a:hover { color: var(--white); }
 
+    /* Calendly Embed Section */
+    .lp-calendly-section {
+      padding: 60px 0;
+      background-color: #f8f9fa;
+    }
+    .lp-calendly-section .lp-container {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+    .lp-calendly-section h2 {
+      font-family: var(--font-display);
+      font-size: clamp(26px, 3.5vw, 34px);
+      font-weight: 700;
+      color: var(--gray-900);
+      text-align: center;
+      margin-bottom: 8px;
+    }
+    .lp-calendly-section p {
+      text-align: center;
+      color: #6c757d;
+      margin-bottom: 30px;
+      max-width: 600px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .calendly-inline-widget {
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    /* Divider */
+    .lp-divider {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 32px;
+      color: var(--gray-400);
+      font-size: 14px;
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .lp-divider::before,
+    .lp-divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: var(--gray-200);
+    }
+
     /* Callback Form */
     .callback-section {
       background: var(--gray-50);
@@ -750,7 +801,7 @@
       <h1 class="hero__title">Your Parking Lot Is Sitting on <span>Untapped Revenue</span></h1>
       <p class="hero__sub">Let us help you capture it, whether that means starting paid parking, replacing an outdated system, or optimizing what you have. No upfront costs. No long-term contracts. Just results.</p>
       <div class="hero__cta-group">
-        <a href="#CALENDLY_LINK" class="btn-primary">
+        <a href="#schedule" class="btn-primary">
           Schedule Your Free Consultation
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
         </a>
@@ -927,16 +978,26 @@
     <div class="final-cta__inner">
       <h2>Ready to See What Your Lot Could Earn?</h2>
       <p>Join property owners across the country who are turning empty parking spaces into real monthly income. It starts with a conversation.</p>
-      <a href="#CALENDLY_LINK" class="btn-primary">
+      <a href="#schedule" class="btn-primary">
         Schedule Your Free Consultation
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
       </a>
     </div>
   </section>
 
+  <section class="lp-section lp-calendly-section" id="schedule">
+    <div class="lp-container">
+      <h2>Schedule Your Free Consultation</h2>
+      <p>Pick a time that works. A parking revenue specialist will call you for a no-pressure conversation about your property.</p>
+      <div class="calendly-inline-widget" data-url="https://calendly.com/d/cxtd-94s-fmm/free-parking-consultation?hide_gdpr_banner=1&background_color=f8f9fa&primary_color=0b6efd" style="min-width:320px;height:700px;"></div>
+    </div>
+  </section>
+
   <section class="callback-section">
     <div class="callback-section__inner">
-      <div class="callback-section__divider">or</div>
+      <div class="lp-divider">
+        <span>or request a callback</span>
+      </div>
       <h3>Prefer We Reach Out to You?</h3>
       <p>Drop your info below and we will call you within one business day.</p>
       <form class="callback-form" id="callbackForm" action="https://formspree.io/f/mqegwawp" method="POST">
@@ -1014,6 +1075,8 @@
       });
     })();
   </script>
+
+  <script src="https://assets.calendly.com/assets/external/widget.js" type="text/javascript" async></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
Integrated Calendly scheduling widget into the consultation landing page to provide a seamless booking experience alongside the existing callback form option.

## Key Changes
- **Added Calendly embed section** with dedicated styling (`lp-calendly-section`) positioned before the callback form
  - Includes section heading, description text, and embedded Calendly widget
  - Configured with custom styling (light gray background, rounded corners, custom colors)
  - Set to 700px height with responsive minimum width

- **Updated CTA link anchors** from placeholder `#CALENDLY_LINK` to `#schedule` in:
  - Hero section primary CTA button
  - Final CTA section button
  - Now properly anchor to the new Calendly section

- **Improved divider styling** between scheduling options
  - Replaced simple "or" text with styled `.lp-divider` component
  - Added decorative horizontal lines with centered text ("or request a callback")
  - Uses flexbox layout with consistent spacing and typography

- **Added Calendly widget script** 
  - Imported external Calendly widget JavaScript library asynchronously
  - Configured widget with specific Calendly URL and customizations (GDPR banner hidden, background/primary colors matched to design)

## Implementation Details
- Calendly widget URL includes parameters for visual customization and GDPR compliance
- New section uses existing design system variables (colors, spacing, typography)
- Maintains responsive design with `clamp()` for heading font sizes
- Preserves existing callback form as alternative scheduling method

https://claude.ai/code/session_01EzBMyuZbYspHiXZKztgAK2