### PR TITLE
Redesign services page for vendor-neutral consultancy positioning

### DIFF
--- a/services/index.html
+++ b/services/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Parking Revenue Services | Scan to Pay & LPR Solutions</title>
-  <meta name="description" content="Expert parking monetization consulting for property owners. We match you with the right technology for maximum revenue. Free assessment available.">
+  <title>Parking Revenue Consultancy | Monetize Parking Services</title>
+  <meta name="description" content="Vendor-neutral parking revenue consultancy. Every parking asset has untapped revenue across paid parking, EV charging, digital advertising, and operational consulting.">
   <meta property="og:image" content="https://monetize-parking.com/images/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
@@ -27,75 +27,19 @@
   <link rel="preload" href="/styles.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="/styles.css"></noscript>
   <link rel="canonical" href="https://monetize-parking.com/services/">
-  <meta property="og:title" content="Parking Revenue Services | Scan to Pay & LPR Solutions">
-  <meta property="og:description" content="Expert parking monetization consulting for property owners. We match you with the right technology for maximum revenue. Free assessment available.">
+  <meta property="og:title" content="Parking Revenue Consultancy | Monetize Parking Services">
+  <meta property="og:description" content="Vendor-neutral parking revenue consultancy. Every parking asset has untapped revenue across paid parking, EV charging, digital advertising, and operational consulting.">
   <meta property="og:url" content="https://monetize-parking.com/services/">
   <meta property="og:site_name" content="Monetize Parking">
-  <meta name="twitter:title" content="Parking Revenue Services | Scan to Pay & LPR Solutions">
-  <meta name="twitter:description" content="Expert parking monetization consulting for property owners. We match you with the right technology for maximum revenue. Free assessment available.">
+  <meta name="twitter:title" content="Parking Revenue Consultancy | Monetize Parking Services">
+  <meta name="twitter:description" content="Vendor-neutral parking revenue consultancy. Every parking asset has untapped revenue across paid parking, EV charging, digital advertising, and operational consulting.">
 <script defer src="/script.js"></script>
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "WebPage",
-  "name": "Parking Revenue Services | Scan to Pay & LPR Solutions",
-  "description": "Expert parking monetization consulting for property owners. We match you with the right technology for maximum revenue. Free assessment available."
-}
-  </script>
-  <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "FAQPage",
-  "mainEntity": [
-    {
-      "@type": "Question",
-      "name": "What parking solutions does Monetize Parking offer?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Monetize Parking partners with industry-leading technology providers to deliver two main solutions: Scan to Pay and License Plate Recognition (LPR). Both solutions run through a single platform, making it easy to track activity, manage payments, and grow your revenue. Scan to Pay allows customers to pay directly from any smartphone without app downloads, while LPR provides automated plate capture with 24/7 enforcement."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "When should I choose Scan to Pay vs License Plate Recognition?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Scan to Pay is ideal for customer-facing businesses like retail, restaurants, and medical offices, properties with lower violation rates, locations requiring quick deployment, and budget-conscious implementations. LPR is better suited for residential or employee parking areas, properties with higher violation rates, tow-enforced locations, and situations requiring hands-off enforcement. Our consultants analyze your property's specific factors to recommend the optimal solution."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "How does the consultation and selection process work?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Our consultants analyze six key factors to recommend the optimal solution: Layout & Traffic Flow (physical property design and traffic patterns), Duration & Turnover (average parking duration and space turnover), Violation Rate (current abuse levels and enforcement challenges), Budget & Timeline (available investment and launch timeframe), Staffing Resources (available personnel for monitoring), and Local Requirements (municipal regulations and compliance needs)."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Can I customize the parking system for my property?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Yes, every platform deployment is fully customizable to your property's operational requirements. You can set flexible rules including custom parking hours, pricing tiers, and time limits. You can add easy exemptions by adding employee or tenant license plates for automatic free parking access. You can also define dynamic hours with different rules for weekdays vs. weekends, or business hours vs. after-hours."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "What is included in implementation and ongoing support?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "Implementation includes Strategic Planning (site assessment, solution recommendation, signage strategy), Deployment (partner coordination, installation management, QR code design and placement), and Training & Handoff (owner and staff training, dashboard walkthrough, documentation). Ongoing support includes revenue tracking and performance reviews, appeals workflow and dispute resolution support, and system updates with optimization recommendations."
-      }
-    },
-    {
-      "@type": "Question",
-      "name": "Do I need complex hardware installations to get started?",
-      "acceptedAnswer": {
-        "@type": "Answer",
-        "text": "No, our solutions are designed for simple setup with no complex hardware installations or IT infrastructure needed to get started. Scan to Pay requires minimal investment and can be launched quickly. Even LPR systems are deployed efficiently by our partner network with professional installation management included in the implementation process."
-      }
-    }
-  ]
+  "name": "Parking Revenue Consultancy | Monetize Parking Services",
+  "description": "Vendor-neutral parking revenue consultancy. Every parking asset has untapped revenue across paid parking, EV charging, digital advertising, and operational consulting."
 }
   </script>
   <script type="application/ld+json">
@@ -127,70 +71,64 @@
     gtag('config', 'G-LGHS0L5WE8');
   </script>
   <style>
-    /* Hero Section - Split Layout */
-    .hero-section {
+    /* Services page: scoped styles */
+
+    /* Hero */
+    .services-hero {
       position: relative;
-      min-height: 600px;
-      display: flex;
-      align-items: stretch;
-      overflow: hidden;
-    }
-
-    .hero-split-container {
-      display: flex;
-      width: 100%;
-      max-width: 1400px;
-      margin: 0 auto;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-    }
-
-    /* Left Side - Text Content */
-    .hero-text-side {
-      flex: 0 0 45%;
-      background: linear-gradient(135deg, #f8fafc 0%, #ffffff 100%);
+      min-height: 560px;
       display: flex;
       align-items: center;
-      padding: 80px 60px;
-      position: relative;
+      overflow: hidden;
     }
-
-    .hero-text-side::after {
-      content: '';
+    .services-hero-image {
       position: absolute;
-      right: 0;
-      top: 0;
-      bottom: 0;
-      width: 1px;
-      background: linear-gradient(to bottom,
-        transparent 0%,
-        rgba(0, 0, 0, 0.08) 20%,
-        rgba(0, 0, 0, 0.08) 80%,
-        transparent 100%);
-      box-shadow: 2px 0 8px rgba(0, 0, 0, 0.03);
+      inset: 0;
+      display: block;
     }
-
-    .hero-text-content {
-      max-width: 520px;
+    .services-hero-image img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+      display: block;
     }
-
-    .hero-section h1 {
-      font-size: clamp(2rem, 4vw, 2.75rem);
+    .services-hero-overlay {
+      position: relative;
+      width: 100%;
+      background: linear-gradient(115deg, rgba(15, 23, 42, 0.78) 0%, rgba(15, 23, 42, 0.55) 55%, rgba(15, 23, 42, 0.25) 100%);
+      min-height: 560px;
+      display: flex;
+      align-items: center;
+      padding: 80px 20px;
+    }
+    .services-hero-content {
+      max-width: 1100px;
+      margin: 0 auto;
+      width: 100%;
+    }
+    .services-hero-content h1 {
+      color: #fff;
+      font-size: clamp(2rem, 4.5vw, 3.25rem);
       font-weight: 700;
-      margin: 0 0 28px 0;
-      line-height: 1.2;
-      color: var(--ink);
+      line-height: 1.15;
       letter-spacing: -0.02em;
+      margin: 0 0 24px 0;
+      max-width: 760px;
+      text-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
     }
-
-    .hero-section p {
-      font-size: clamp(1rem, 1.8vw, 1.125rem);
-      line-height: 1.7;
-      color: var(--muted);
+    .services-hero-content p {
+      color: rgba(255, 255, 255, 0.95);
+      font-size: clamp(1.0625rem, 1.6vw, 1.25rem);
+      line-height: 1.65;
       margin: 0 0 36px 0;
+      max-width: 720px;
+      text-shadow: 0 1px 6px rgba(0, 0, 0, 0.25);
     }
-
-    .hero-cta {
-      display: inline-block;
+    .services-hero-cta {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       padding: 16px 36px;
       background: var(--brand);
       color: #fff;
@@ -199,521 +137,267 @@
       font-weight: 600;
       font-size: 1.0625rem;
       transition: transform 0.2s, box-shadow 0.2s;
-      box-shadow: 0 4px 12px rgba(11, 110, 253, 0.2);
+      box-shadow: 0 10px 32px rgba(11, 110, 253, 0.35);
     }
-
-    .hero-cta:hover {
+    .services-hero-cta:hover {
       transform: translateY(-2px);
-      box-shadow: 0 8px 24px rgba(11, 110, 253, 0.35);
+      box-shadow: 0 14px 36px rgba(11, 110, 253, 0.45);
     }
-
-    /* Right Side - Image */
-    .hero-image-side {
-      flex: 0 0 55%;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .hero-image-side img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-      object-position: center;
-    }
-
-    /* Responsive Design */
-    @media (max-width: 968px) {
-      .hero-section {
-        min-height: auto;
-      }
-
-      .hero-split-container {
-        flex-direction: column;
-      }
-
-      .hero-text-side {
-        flex: 1;
-        padding: 60px 40px;
-      }
-
-      .hero-text-side::after {
-        display: none;
-      }
-
-      .hero-text-content {
-        max-width: 100%;
-      }
-
-      .hero-image-side {
-        flex: 1;
-        min-height: 400px;
-      }
-    }
-
     @media (max-width: 640px) {
-      .hero-text-side {
-        padding: 50px 24px;
+      .services-hero,
+      .services-hero-overlay {
+        min-height: 480px;
       }
-
-      .hero-section h1 {
-        margin-bottom: 20px;
-      }
-
-      .hero-section p {
-        margin-bottom: 28px;
-      }
-
-      .hero-image-side {
-        min-height: 320px;
+      .services-hero-overlay {
+        padding: 64px 20px;
       }
     }
 
-    /* Key Benefits Section */
-    .benefits-section {
+    /* Shared section intro */
+    .services-section-intro {
+      text-align: center;
+      max-width: 820px;
+      margin: 0 auto 56px;
+    }
+    .services-section-intro h2 {
+      font-size: clamp(2rem, 4vw, 2.625rem);
+      font-weight: 700;
+      margin: 0 0 16px 0;
+    }
+    .services-section-intro p {
+      font-size: 1.125rem;
+      color: var(--muted);
+      line-height: 1.65;
+      max-width: none;
+      margin: 0 auto;
+    }
+
+    /* How We Work */
+    .services-process {
       padding: 100px 0;
       background: #fff;
     }
-    .benefits-grid {
+    .services-process-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 40px;
-      margin-top: 60px;
-    }
-    .benefit-card {
-      text-align: center;
-      padding: 32px 24px;
-      background: var(--bg);
-      border-radius: 8px;
-      transition: transform 0.2s;
-    }
-    .benefit-card:hover {
-      transform: translateY(-4px);
-    }
-    .benefit-card h3 {
-      font-size: 1.25rem;
-      font-weight: 600;
-      margin: 0 0 12px 0;
-      color: var(--ink);
-    }
-    .benefit-card p {
-      font-size: 1rem;
-      line-height: 1.6;
-      color: var(--muted);
-      margin: 0;
-    }
-
-    /* Solution Comparison Section */
-    .comparison-section {
-      padding: 100px 0;
-      background: var(--bg);
-    }
-
-    /* Banner Header with Overlay */
-    .comparison-banner {
-      position: relative;
-      width: 100%;
-      height: 400px;
-      border-radius: 16px;
-      overflow: hidden;
-      margin-bottom: 60px;
-    }
-    .comparison-banner img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-    .comparison-banner-overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background: linear-gradient(135deg, rgba(11, 110, 253, 0.85) 0%, rgba(8, 86, 201, 0.85) 100%);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      padding: 40px 20px;
-    }
-    .comparison-banner-overlay h2 {
-      font-size: clamp(2.5rem, 5vw, 3.5rem);
-      font-weight: 700;
-      color: #fff;
-      margin: 0 0 16px 0;
-      text-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-    }
-    .comparison-banner-overlay p {
-      font-size: clamp(1.25rem, 2.5vw, 1.5rem);
-      color: rgba(255, 255, 255, 0.95);
-      margin: 0;
-      max-width: 600px;
-    }
-
-    @media (max-width: 768px) {
-      .comparison-banner {
-        height: 300px;
-      }
-    }
-
-    /* Two-Column Grid */
-    .comparison-grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 40px;
-      align-items: start;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 32px;
     }
     @media (max-width: 900px) {
-      .comparison-grid {
+      .services-process-grid {
         grid-template-columns: 1fr;
-        gap: 32px;
       }
     }
-
-    /* Solution Cards */
-    .solution-card {
-      background: #fff;
-      border-radius: 16px;
-      border: 2px solid var(--border);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-      overflow: hidden;
-      transition: transform 0.3s, box-shadow 0.3s;
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-    .solution-card:hover {
-      transform: translateY(-4px);
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
-    }
-
-    .solution-card-image {
-      width: 100%;
-      height: 280px;
-      overflow: hidden;
-    }
-    .solution-card-image img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-
-    .solution-card-content {
-      padding: 32px;
-      flex: 1;
-    }
-
-    .solution-card h3 {
-      font-size: 1.875rem;
-      font-weight: 700;
-      margin: 0 0 24px 0;
-      color: var(--ink);
-      border-bottom: 3px solid var(--brand);
-      padding-bottom: 12px;
-    }
-    .solution-card h4 {
-      font-size: 1rem;
-      font-weight: 600;
-      color: var(--muted);
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      margin: 24px 0 16px 0;
-    }
-    .solution-card ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-    .solution-card li {
-      padding: 10px 0 10px 32px;
-      position: relative;
-      line-height: 1.7;
-      color: var(--ink);
-      font-size: 0.9375rem;
-    }
-    .solution-card li:before {
-      content: "✓";
-      position: absolute;
-      left: 0;
-      top: 10px;
-      color: var(--brand);
-      font-weight: 700;
-      font-size: 1.25rem;
-      width: 24px;
-      height: 24px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: rgba(11, 110, 253, 0.1);
-      border-radius: 50%;
-    }
-
-    /* Consultation Process Section */
-    .consultation-section {
-      padding: 100px 0;
-      background: #fff;
-    }
-    .consultation-intro {
-      text-align: center;
-      max-width: 800px;
-      margin: 0 auto 60px;
-    }
-    .consultation-intro h2 {
-      font-size: clamp(2rem, 4vw, 2.625rem);
-      font-weight: 700;
-      margin: 0 0 20px 0;
-    }
-    .consultation-intro p {
-      font-size: 1.125rem;
-      color: var(--muted);
-      line-height: 1.6;
-    }
-    .factors-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 40px;
-    }
-    .factor-card {
-      padding: 32px;
+    .services-process-card {
+      padding: 40px 32px;
       background: var(--bg);
-      border-radius: 8px;
-      border-left: 4px solid var(--brand);
+      border-radius: 12px;
+      border-top: 4px solid var(--brand);
     }
-    .factor-card h3 {
-      font-size: 1.25rem;
+    .services-process-number {
+      font-size: 2.5rem;
+      font-weight: 700;
+      color: var(--brand);
+      line-height: 1;
+      margin-bottom: 16px;
+      letter-spacing: -0.02em;
+    }
+    .services-process-card h3 {
+      font-size: 1.375rem;
       font-weight: 600;
       margin: 0 0 12px 0;
       color: var(--ink);
     }
-    .factor-card p {
+    .services-process-card p {
       font-size: 1rem;
       color: var(--muted);
-      line-height: 1.6;
+      line-height: 1.65;
       margin: 0;
-    }
-
-    /* Customization Section */
-    .customization-section {
-      padding: 100px 0;
-      background: var(--bg);
-    }
-    .customization-intro {
-      text-align: center;
-      max-width: 800px;
-      margin: 0 auto 60px;
-    }
-    .customization-intro h2 {
-      font-size: clamp(2rem, 4vw, 2.625rem);
-      font-weight: 700;
-      margin: 0 0 20px 0;
-    }
-    .customization-intro p {
-      font-size: 1.125rem;
-      color: var(--muted);
-      line-height: 1.6;
-    }
-    .customization-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-      gap: 40px;
-    }
-    .customization-card {
-      background: #fff;
-      padding: 40px;
-      border-radius: 12px;
-      border: 2px solid var(--border);
-    }
-    .customization-card h3 {
-      font-size: 1.5rem;
-      font-weight: 600;
-      margin: 0 0 16px 0;
-      color: var(--ink);
-    }
-    .customization-card p {
-      font-size: 1rem;
-      color: var(--muted);
-      line-height: 1.6;
-      margin: 0;
-    }
-
-    /* Implementation Section */
-    .implementation-section {
-      padding: 100px 0;
-      background: #fff;
-    }
-    .implementation-intro {
-      text-align: center;
-      max-width: 800px;
-      margin: 0 auto 60px;
-    }
-    .implementation-intro h2 {
-      font-size: clamp(2rem, 4vw, 2.625rem);
-      font-weight: 700;
-      margin: 0 0 20px 0;
-    }
-    .implementation-intro p {
-      font-size: 1.125rem;
-      color: var(--muted);
-      line-height: 1.6;
-    }
-    .implementation-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-      gap: 40px;
-    }
-    .implementation-card {
-      text-align: center;
-      padding: 32px 24px;
-      background: var(--bg);
-      border-radius: 8px;
-    }
-    .implementation-card h3 {
-      font-size: 1.25rem;
-      font-weight: 600;
-      margin: 0 0 16px 0;
-      color: var(--ink);
-      padding-bottom: 12px;
-      border-bottom: 3px solid var(--brand);
-    }
-    .implementation-card ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      text-align: left;
-    }
-    .implementation-card li {
-      padding: 6px 0 6px 24px;
-      position: relative;
-      font-size: 0.9375rem;
-      line-height: 1.6;
-      color: var(--muted);
-    }
-    .implementation-card li:before {
-      content: "•";
-      position: absolute;
-      left: 8px;
-      color: var(--brand);
-      font-weight: 700;
-    }
-
-    /* Beyond Paid Parking Section */
-    .beyond-section {
-      padding: 100px 0;
-      background: var(--bg);
-    }
-    .beyond-intro {
-      text-align: center;
-      max-width: 800px;
-      margin: 0 auto 60px;
-    }
-    .beyond-intro h2 {
-      font-size: clamp(2rem, 4vw, 2.625rem);
-      font-weight: 700;
-      margin: 0 0 20px 0;
-    }
-    .beyond-intro p {
-      font-size: 1.125rem;
-      color: var(--muted);
-      line-height: 1.6;
       max-width: none;
     }
-    .beyond-grid {
+
+    /* Revenue Streams */
+    .services-streams {
+      padding: 100px 0;
+      background: var(--bg);
+    }
+    .services-streams-grid {
       display: grid;
       grid-template-columns: 1fr 1fr;
-      gap: 40px;
+      gap: 32px;
     }
     @media (max-width: 768px) {
-      .beyond-grid {
+      .services-streams-grid {
         grid-template-columns: 1fr;
         gap: 24px;
       }
     }
-    .beyond-card {
+    .services-stream-card {
       background: #fff;
       padding: 40px;
       border-radius: 12px;
       border: 2px solid var(--border);
       transition: transform 0.2s, box-shadow 0.2s;
+      display: flex;
+      flex-direction: column;
     }
-    .beyond-card:hover {
+    .services-stream-card:hover {
       transform: translateY(-4px);
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
     }
-    .beyond-card h3 {
+    .services-stream-card h3 {
       font-size: 1.5rem;
       font-weight: 600;
       margin: 0 0 16px 0;
       color: var(--ink);
+      padding-bottom: 12px;
+      border-bottom: 3px solid var(--brand);
     }
-    .beyond-card p {
+    .services-stream-card p {
       font-size: 1rem;
       color: var(--muted);
-      line-height: 1.6;
-      margin: 0;
-    }
-    .beyond-closing {
-      text-align: center;
-      max-width: 800px;
-      margin: 60px auto 40px;
-    }
-    .beyond-closing p {
-      font-size: 1.125rem;
-      color: var(--muted);
       line-height: 1.7;
+      margin: 0;
       max-width: none;
     }
-    /* Final CTA Section */
-    .final-cta-section {
+
+    /* Audience / Not Sure Where to Start */
+    .services-audience {
+      padding: 100px 0;
+      background: #fff;
+    }
+    .services-audience-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 32px;
+    }
+    @media (max-width: 900px) {
+      .services-audience-grid {
+        grid-template-columns: 1fr;
+      }
+    }
+    .services-audience-card {
+      padding: 32px;
+      background: var(--bg);
+      border-radius: 12px;
+      border-left: 4px solid var(--brand);
+    }
+    .services-audience-card h3 {
+      font-size: 1.25rem;
+      font-weight: 600;
+      margin: 0 0 12px 0;
+      color: var(--ink);
+    }
+    .services-audience-card p {
+      font-size: 1rem;
+      color: var(--muted);
+      line-height: 1.65;
+      margin: 0;
+      max-width: none;
+    }
+
+    /* Proven Impact */
+    .services-impact {
+      padding: 100px 0;
+      background: var(--bg);
+    }
+    .services-impact-stats {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 32px;
+      max-width: 1000px;
+      margin: 0 auto 32px;
+    }
+    @media (max-width: 768px) {
+      .services-impact-stats {
+        grid-template-columns: 1fr;
+        gap: 20px;
+      }
+    }
+    .services-stat {
+      background: #fff;
+      padding: 40px 24px;
+      border-radius: 12px;
+      border: 2px solid var(--border);
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .services-stat-number {
+      font-size: clamp(2.25rem, 4vw, 3rem);
+      font-weight: 700;
+      color: var(--brand);
+      letter-spacing: -0.02em;
+      line-height: 1;
+    }
+    .services-stat-label {
+      font-size: 1rem;
+      color: var(--ink);
+      line-height: 1.4;
+      font-weight: 500;
+    }
+    .services-impact-disclaimer {
+      text-align: center;
+      font-size: 0.9375rem;
+      color: var(--muted);
+      max-width: 720px;
+      margin: 0 auto 20px;
+      font-style: italic;
+    }
+    .services-impact-link {
+      text-align: center;
+      font-size: 1.125rem;
+      margin: 0;
+      max-width: none;
+    }
+    .services-impact-link a {
+      color: var(--brand);
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .services-impact-link a:hover {
+      text-decoration: underline;
+    }
+
+    /* Final CTA */
+    .services-final-cta {
       padding: 100px 0;
       background: linear-gradient(135deg, #0b6efd 0%, #0856c9 100%);
       color: #fff;
     }
-    .final-cta-content {
+    .services-final-cta-content {
       text-align: center;
-      max-width: 700px;
+      max-width: 760px;
       margin: 0 auto;
     }
-    .final-cta-section h2 {
+    .services-final-cta h2 {
       font-size: clamp(2rem, 4vw, 2.625rem);
       font-weight: 700;
       margin: 0 0 20px 0;
       color: #fff;
     }
-    .final-cta-section p {
-      font-size: 1.25rem;
-      margin: 0 0 40px 0;
+    .services-final-cta p {
+      font-size: 1.125rem;
+      margin: 0 auto 36px;
       opacity: 0.95;
-      line-height: 1.6;
+      line-height: 1.65;
+      color: #fff;
+      max-width: 640px;
     }
-    .final-cta-button {
+    .services-final-cta-button {
       display: inline-block;
-      padding: 18px 48px;
+      padding: 18px 40px;
       background: #fff;
       color: var(--brand);
       text-decoration: none;
       border-radius: 8px;
       font-weight: 700;
-      font-size: 1.25rem;
+      font-size: 1.125rem;
       transition: transform 0.2s, box-shadow 0.2s;
-      margin-bottom: 20px;
     }
-    .final-cta-button:hover {
+    .services-final-cta-button:hover {
       transform: translateY(-2px);
       box-shadow: 0 12px 28px rgba(0, 0, 0, 0.2);
-    }
-    .final-cta-secondary {
-      display: block;
-      color: #fff;
-      font-size: 1.125rem;
-      opacity: 0.9;
-      margin-top: 16px;
-    }
-    .final-cta-secondary a {
-      color: #fff;
-      text-decoration: underline;
     }
   </style>
 </head>
@@ -742,313 +426,130 @@
   </header>
 
   <main id="main">
-    <!-- Hero Section -->
-    <section class="hero-section">
-      <div class="hero-split-container">
-        <!-- Left Side: Text Content -->
-        <div class="hero-text-side">
-          <div class="hero-text-content">
-            <h1>Modern Parking Solutions Built for Your Property</h1>
-            <p>
-              Partnering with industry-leading technology providers, our team delivers
-              Scan to Pay and License Plate Recognition (LPR) systems that maximize
-              revenue while minimizing operational hassle. Everything runs through a
-              single platform, making it easy to track activity, manage payments,
-              and grow your bottom line.
-            </p>
-            <a href="#comparison" class="hero-cta">Learn More</a>
-          </div>
-        </div>
-
-        <!-- Right Side: Image -->
-        <div class="hero-image-side">
-          <picture>
-            <source srcset="/images/services.webp" type="image/webp">
-            <img src="/images/services.jpg" alt="Modern parking facility with professional management technology" width="3992" height="2242">
-          </picture>
+    <!-- Hero -->
+    <section class="services-hero">
+      <picture class="services-hero-image">
+        <source srcset="/images/services.webp" type="image/webp">
+        <img src="/images/services.jpg" alt="Commercial parking facility" width="3992" height="2242">
+      </picture>
+      <div class="services-hero-overlay">
+        <div class="services-hero-content">
+          <h1>Every Parking Asset Has Untapped Revenue</h1>
+          <p>Monetize Parking is a vendor-neutral consultancy that identifies every revenue opportunity a parking asset can support and connects property owners with the right partners to capture it. Paid parking is one lever. There are others.</p>
+          <a href="/contact/" class="services-hero-cta">Schedule a Free Consultation</a>
         </div>
       </div>
     </section>
 
-    <!-- Key Benefits Section -->
-    <section class="benefits-section">
+    <!-- How We Work -->
+    <section class="services-process">
       <div class="container">
-        <h2 style="text-align: center; font-size: clamp(2rem, 4vw, 2.625rem); margin-bottom: 16px;">Why Property Owners Choose These Solutions</h2>
-
-        <div class="benefits-grid">
-          <div class="benefit-card">
-            <h3>Frictionless Payments</h3>
-            <p>Customers pay directly from any smartphone-no app downloads or accounts required.</p>
+        <div class="services-section-intro">
+          <h2>How We Work</h2>
+        </div>
+        <div class="services-process-grid">
+          <div class="services-process-card">
+            <div class="services-process-number">01</div>
+            <h3>Assess</h3>
+            <p>Every engagement starts with a full evaluation of the property, traffic patterns, tenant needs, and existing infrastructure. No recommendations are made before the asset is understood.</p>
           </div>
-
-          <div class="benefit-card">
-            <h3>Automated Enforcement</h3>
-            <p>License plate recognition with timestamped photo evidence handles compliance automatically.</p>
+          <div class="services-process-card">
+            <div class="services-process-number">02</div>
+            <h3>Match to Partners</h3>
+            <p>Based on the assessment, each property is matched with technology and service partners that fit its layout, demand profile, and revenue goals. No vendor affiliations influence the recommendation.</p>
           </div>
-
-          <div class="benefit-card">
-            <h3>Unified Platform</h3>
-            <p>Single dashboard tracks all activity, payments, and violations across your properties.</p>
-          </div>
-
-          <div class="benefit-card">
-            <h3>Real-Time Alerts</h3>
-            <p>Instant notifications keep you informed of violations, payments, and system status.</p>
-          </div>
-
-          <div class="benefit-card">
-            <h3>Simple Setup</h3>
-            <p>No complex hardware installations or IT infrastructure needed to get started.</p>
+          <div class="services-process-card">
+            <div class="services-process-number">03</div>
+            <h3>Optimize Over Time</h3>
+            <p>Revenue does not stop at installation. Ongoing monitoring, compliance tracking, and periodic vendor reviews ensure each revenue stream continues to perform and grow.</p>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- Solution Comparison Section -->
-    <section id="comparison" class="comparison-section">
+    <!-- Revenue Streams -->
+    <section class="services-streams">
       <div class="container">
-        <!-- Banner Header with Combined Photo -->
-        <div class="comparison-banner">
-          <picture>
-            <source srcset="/images/scan_lpr.webp" type="image/webp">
-            <img src="/images/scan_lpr.jpg" alt="Scan to Pay and License Plate Recognition Solutions" width="4000" height="3000" loading="lazy">
-          </picture>
-          <div class="comparison-banner-overlay">
-            <h2>One Platform, Two Solutions</h2>
-            <p>Flexible Options for Every Property</p>
-          </div>
+        <div class="services-section-intro">
+          <h2>Revenue Streams</h2>
         </div>
-
-        <!-- Two-Column Layout -->
-        <div class="comparison-grid">
-          <!-- Scan to Pay Card -->
-          <div class="solution-card">
-            <div class="solution-card-image">
-              <picture>
-                <source srcset="/images/scan.webp" type="image/webp">
-                <img src="/images/scan.jpg" alt="Scan to Pay - Customer scanning QR code for parking payment" width="4000" height="3000" loading="lazy">
-              </picture>
-            </div>
-            <div class="solution-card-content">
-              <h3>Scan to Pay</h3>
-
-              <h4>Common Use Cases</h4>
-              <ul>
-                <li>Customer-facing businesses (retail, restaurants, medical offices)</li>
-                <li>Properties with lower historical violation rates</li>
-                <li>Locations requiring quick deployment</li>
-                <li>Budget-conscious initial implementations</li>
-              </ul>
-
-              <h4>Key Features</h4>
-              <ul>
-                <li>Fast launch and minimal investment</li>
-                <li>Works on any smartphone (no app required)</li>
-                <li>Built-in grace periods and clear customer communication</li>
-                <li>Payment history creates instant audit trails</li>
-              </ul>
-            </div>
+        <div class="services-streams-grid">
+          <div class="services-stream-card">
+            <h3>Paid Parking Systems</h3>
+            <p>Scan-to-Pay and License Plate Recognition systems matched to each property's layout, traffic patterns, and tenant needs. No one-size-fits-all recommendations. Every lot gets a tailored approach based on demand, competitive pricing, and how the property operates today. Whether replacing outdated meters and gates or launching paid parking for the first time, the right system is selected from a full vendor landscape.</p>
           </div>
-
-          <!-- LPR Card -->
-          <div class="solution-card">
-            <div class="solution-card-image">
-              <picture>
-                <source srcset="/images/camera_lot.webp" type="image/webp">
-                <img src="/images/camera_lot.jpg" alt="License Plate Recognition - Automated parking enforcement camera" width="3000" height="4000" loading="lazy">
-              </picture>
-            </div>
-            <div class="solution-card-content">
-              <h3>LPR (License Plate Recognition)</h3>
-
-              <h4>Common Use Cases</h4>
-              <ul>
-                <li>Residential or employee parking areas</li>
-                <li>Properties with higher historical violation rates</li>
-                <li>Tow-enforced locations</li>
-                <li>Situations requiring hands-off enforcement</li>
-              </ul>
-
-              <h4>Key Features</h4>
-              <ul>
-                <li>Automated plate capture with photo proof</li>
-                <li>Zero customer interaction needed</li>
-                <li>Consistent enforcement 24/7</li>
-                <li>Complete documentation for disputes</li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Consultation Process Section -->
-    <section class="consultation-section">
-      <div class="container">
-        <div class="consultation-intro">
-          <h2>How the Selection Process Works</h2>
-          <p>
-            Our consultants analyze six key factors to recommend the optimal solution
-            for your property's unique situation.
-          </p>
-        </div>
-
-        <div class="factors-grid">
-          <div class="factor-card">
-            <h3>Layout & Traffic Flow</h3>
-            <p>Physical property design, entry/exit points, and typical traffic patterns.</p>
-          </div>
-
-          <div class="factor-card">
-            <h3>Duration & Turnover</h3>
-            <p>Average parking duration and how frequently spaces turn over.</p>
-          </div>
-
-          <div class="factor-card">
-            <h3>Violation Rate</h3>
-            <p>Current abuse levels, freeloading patterns, and enforcement challenges.</p>
-          </div>
-
-          <div class="factor-card">
-            <h3>Budget & Timeline</h3>
-            <p>Available investment and desired launch timeframe.</p>
-          </div>
-
-          <div class="factor-card">
-            <h3>Staffing Resources</h3>
-            <p>Available personnel for monitoring and enforcement support.</p>
-          </div>
-
-          <div class="factor-card">
-            <h3>Local Requirements</h3>
-            <p>Municipal regulations, signage laws, and compliance needs.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Customization Section -->
-    <section class="customization-section">
-      <div class="container">
-        <div class="customization-intro">
-          <h2>Customization & Control</h2>
-          <p>Every platform deployment is tailored to your property's operational requirements.</p>
-        </div>
-
-        <div class="customization-grid">
-          <div class="customization-card">
-            <h3>Flexible Rules</h3>
-            <p>Set custom parking hours, pricing tiers, and time limits that match your business schedule.</p>
-          </div>
-
-          <div class="customization-card">
-            <h3>Easy Exemptions</h3>
-            <p>Add employee or tenant license plates for automatic free parking access.</p>
-          </div>
-
-          <div class="customization-card">
-            <h3>Dynamic Hours</h3>
-            <p>Define different rules for weekdays vs. weekends, business hours vs. after-hours.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Implementation & Support Section -->
-    <section class="implementation-section">
-      <div class="container">
-        <div class="implementation-intro">
-          <h2>Implementation & Ongoing Support</h2>
-          <p>
-            From deployment through daily operations, our team handles the details
-            so you can focus on revenue growth.
-          </p>
-        </div>
-
-        <div class="implementation-grid">
-          <div class="implementation-card">
-            <h3>Strategic Planning</h3>
-            <ul>
-              <li>Site assessment and solution recommendation</li>
-              <li>Signage strategy and placement optimization</li>
-              <li>Integration with existing systems</li>
-            </ul>
-          </div>
-
-          <div class="implementation-card">
-            <h3>Deployment</h3>
-            <ul>
-              <li>Partner coordination and installation management</li>
-              <li>QR code design and placement</li>
-              <li>Initial testing and calibration</li>
-            </ul>
-          </div>
-
-          <div class="implementation-card">
-            <h3>Training & Handoff</h3>
-            <ul>
-              <li>Owner and staff training sessions</li>
-              <li>Dashboard walkthrough and reporting setup</li>
-              <li>Documentation and best practices guide</li>
-            </ul>
-          </div>
-
-          <div class="implementation-card">
-            <h3>Ongoing Partnership</h3>
-            <ul>
-              <li>Revenue tracking and performance reviews</li>
-              <li>Appeals workflow and dispute resolution support</li>
-              <li>System updates and optimization recommendations</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Beyond Paid Parking Section -->
-    <section class="beyond-section">
-      <div class="container">
-        <div class="beyond-intro">
-          <h2>Paid Parking Is Just the Starting Point</h2>
-          <p>Monetize Parking is a parking revenue consultancy, not a technology vendor. That means the goal is never to sell a single product. It is to identify every revenue opportunity a parking asset can support and connect property owners with the right partners to capture it.</p>
-        </div>
-
-        <div class="beyond-grid">
-          <div class="beyond-card">
-            <h3>Paid Parking Solutions</h3>
-            <p>Scan-to-Pay and License Plate Recognition systems matched to each property's layout, traffic patterns, and tenant needs. No one-size-fits-all recommendations. Every lot gets a tailored approach based on demand, competitive pricing, and how the property operates today.</p>
-          </div>
-
-          <div class="beyond-card">
+          <div class="services-stream-card">
             <h3>EV Charging</h3>
-            <p>Electric vehicle adoption is accelerating, and parking lots are the natural home for charging infrastructure. Property owners can generate per-session charging revenue while attracting a growing segment of drivers who actively seek out EV-friendly locations. The right charging partner handles installation and maintenance with no upfront cost to the property owner.</p>
+            <p>Electric vehicle adoption is accelerating, and parking lots are a natural home for charging infrastructure. Property owners can generate per-session charging revenue while attracting a growing segment of drivers who actively seek out EV-friendly locations. The right charging partner handles installation and maintenance with no upfront cost to the property owner.</p>
           </div>
-
-          <div class="beyond-card">
-            <h3>Digital Advertising</h3>
+          <div class="services-stream-card">
+            <h3>Digital Advertising and Signage</h3>
             <p>Parking lots see hundreds or thousands of vehicles daily. That foot and vehicle traffic has value. Digital signage, on-site displays, and location-based advertising partnerships can turn visibility into a recurring revenue stream without affecting parking operations.</p>
           </div>
-
-          <div class="beyond-card">
+          <div class="services-stream-card">
             <h3>Operational Consulting</h3>
             <p>Revenue is not just about adding income. It is also about reducing waste. Parking studies, signage strategy, vendor contract reviews, and compliance audits help property owners stop overpaying and start operating more efficiently. Small operational fixes often unlock thousands in annual savings.</p>
           </div>
         </div>
-
-        <div class="beyond-closing">
-          <p>Every parking property is different. A church, an office building, a retail center, and an apartment complex all have different traffic patterns, tenant relationships, and revenue potential. That is exactly why independent consulting matters. No vendor ties. No conflicts of interest. Just a clear-eyed assessment of what each property can earn and the best way to get there.</p>
-        </div>
-
       </div>
     </section>
 
-    <!-- Final CTA Section -->
-    <section class="final-cta-section">
+    <!-- Not Sure Where to Start? -->
+    <section class="services-audience">
       <div class="container">
-        <div class="final-cta-content">
-          <h2>Ready to Maximize Your Parking Revenue?</h2>
-          <p>Schedule a free property consultation to discuss which solution fits your needs.</p>
-          <a href="/contact/" class="final-cta-button">Schedule Consultation</a>
+        <div class="services-section-intro">
+          <h2>Not Sure Where to Start?</h2>
+        </div>
+        <div class="services-audience-grid">
+          <div class="services-audience-card">
+            <h3>Starting from Scratch</h3>
+            <p>The property has free or unmanaged parking and is leaving money on the table. A full assessment identifies which combination of paid parking, EV charging, and advertising revenue the asset can support from day one.</p>
+          </div>
+          <div class="services-audience-card">
+            <h3>Replacing Outdated Technology</h3>
+            <p>The property already charges for parking, but the system is aging, underperforming, or locked into an unfavorable vendor contract. A vendor-neutral review compares current performance against what modern systems deliver and identifies the right upgrade path.</p>
+          </div>
+          <div class="services-audience-card">
+            <h3>Optimizing What You Already Have</h3>
+            <p>The property has a working paid parking operation but revenue has plateaued. Compliance audits, pricing analysis, signage improvements, and additional revenue streams like EV charging can push performance significantly higher without starting over.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Proven Impact -->
+    <section class="services-impact">
+      <div class="container">
+        <div class="services-section-intro">
+          <h2>Results from a Real Property</h2>
+          <p>Eau Claire, WI. A single commercial property replaced its outdated parking system through a vendor-neutral evaluation. The results over the first year:</p>
+        </div>
+        <div class="services-impact-stats">
+          <div class="services-stat">
+            <span class="services-stat-number">178%</span>
+            <span class="services-stat-label">increase in parking revenue</span>
+          </div>
+          <div class="services-stat">
+            <span class="services-stat-number">45% to 90%</span>
+            <span class="services-stat-label">compliance improvement</span>
+          </div>
+          <div class="services-stat">
+            <span class="services-stat-number">$240K</span>
+            <span class="services-stat-label">increase in assessed property value</span>
+          </div>
+        </div>
+        <p class="services-impact-disclaimer">These results reflect a specific client engagement, not industry averages.</p>
+        <p class="services-impact-link"><a href="https://monetize-parking.com/articles/eau-claire-revenue-increase/">Read the full case study &rarr;</a></p>
+      </div>
+    </section>
+
+    <!-- Bottom CTA -->
+    <section class="services-final-cta">
+      <div class="container">
+        <div class="services-final-cta-content">
+          <h2>Find Out What Your Parking Asset Can Generate</h2>
+          <p>A free consultation covers the property's current setup, revenue potential across all applicable streams, and a recommended path forward. No vendor commitments. No obligations.</p>
+          <a href="/contact/" class="services-final-cta-button">Schedule a Free Consultation</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Replaces the Scan-to-Pay / LPR-centric services page with six sections reflecting four equal revenue streams: paid parking systems, EV charging, digital advertising and signage, and operational consulting.
- New structure: Hero → How We Work (3 steps) → Revenue Streams (2×2) → Not Sure Where to Start? (3 audience columns) → Results from a Real Property (Eau Claire stats) → Bottom CTA.
- Preserves the existing hero image (`/images/services.webp`), now used as a full-bleed background with gradient overlay for the new hero copy and CTA.
- Eau Claire case study stats (178% revenue, 45% to 90% compliance, $240K property value) and link to `/articles/eau-claire-revenue-increase/` preserved unchanged.
- Head metadata (title, description, OG, Twitter, WebPage schema) updated to match new positioning. FAQPage JSON-LD removed because its hardcoded Q&A referenced old Scan-to-Pay/LPR content no longer on the page.
- All new CSS scoped with `services-` prefix; global stylesheets, site nav, and footer untouched.
- Copy enforces no em dashes, no first-person (aside from the specified "How We Work" heading), no superlatives, no fabricated stats, vendor-neutral tone.

## Test plan
- [ ] Load `/services/` locally (`python3 -m http.server 8000`) and verify all six sections render in order
- [ ] Confirm hero background image displays with readable text overlay on desktop and mobile
- [ ] Verify 2×2 revenue streams grid collapses to single column on mobile
- [ ] Verify 3-column How We Work and Not Sure Where to Start sections collapse to single column on mobile
- [ ] Click both "Schedule a Free Consultation" CTAs and confirm they route to `/contact/`
- [ ] Click "Read the full case study" and confirm it routes to the Eau Claire article
- [ ] Confirm nav and footer render identically to other pages
- [ ] Run Lighthouse / validator to confirm no broken JSON-LD after FAQPage removal

https://claude.ai/code/session_016wTz6tE2sUsAXRa9VEHSs4