### PR TITLE
Track Calendly bookings separately from callback form conversions

### DIFF
--- a/consultation/index.html
+++ b/consultation/index.html
@@ -1084,7 +1084,11 @@
     window.addEventListener('message', function(e) {
       if (e.origin === 'https://calendly.com' &&
           e.data.event && e.data.event === 'calendly.event_scheduled') {
-        window.location.href = '/consultation/thank-you/';
+        gtag('event', 'calendly_booking', {
+          event_category: 'conversion',
+          event_label: 'ppc_consultation'
+        });
+        window.location.href = '/consultation/thank-you/?source=calendly';
       }
     });
   </script>

--- a/consultation/thank-you/index.html
+++ b/consultation/thank-you/index.html
@@ -411,7 +411,7 @@
 
   <script>
     window.addEventListener('load', function() {
-      if (typeof gtag === 'function') {
+      if (typeof gtag === 'function' && !window.location.search.includes('source=calendly')) {
         gtag('event', 'ppc_callback_conversion', {
           'event_category': 'PPC',
           'event_label': 'Callback Form Submitted'


### PR DESCRIPTION
## Summary
Updated conversion tracking to distinguish between Calendly booking events and callback form submissions, preventing double-counting of conversions in Google Analytics.

## Key Changes
- **Calendly booking event tracking**: Added explicit Google Analytics event (`calendly_booking`) when a user completes a Calendly booking, with conversion category and PPC consultation label
- **Query parameter addition**: Appended `source=calendly` to the thank-you page redirect URL to identify the booking source
- **Conditional conversion tracking**: Modified the thank-you page to skip the callback form conversion event when the user arrives via Calendly (detected via query parameter), preventing duplicate conversion attribution

## Implementation Details
- The Calendly event listener now fires a dedicated GA event before redirecting to the thank-you page
- The thank-you page checks for the `source=calendly` query parameter to conditionally suppress the callback form conversion event
- This ensures each conversion path (Calendly vs. callback form) is tracked independently and accurately in Google Analytics

https://claude.ai/code/session_01TqRVuhQ1BvYX9WRdBbFzg3